### PR TITLE
chore(netlify): configure VITE_API_URL for production, preview, and dev contexts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,12 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[context.production.environment]
+  VITE_API_URL = "https://api.misqabbi.com"
+
+[context.deploy-preview.environment]
+  VITE_API_URL = "https://dev.misqabbi.com"
+
+[context.development.environment]
+  VITE_API_URL = "https://dev.misqabbi.com"


### PR DESCRIPTION
- Added context-specific VITE_API_URL values to netlify.toml
- Ensures correct API endpoint is injected for production, deploy previews, and local dev
