### PR TITLE
feat: add placeholder 404 page and catch-all route in App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import Login from './pages/Login';
 import FinishSignUp from './pages/FinishSignUp';
 
 import './App.css';
+import NotFound from './components/UI/NotFound';
 
 const App = () => {
   return (
@@ -60,6 +61,14 @@ const App = () => {
         <Route path="/register" element={<Register />} />
         <Route path="/finishSignUp" element={<FinishSignUp />} />
         <Route path="/login" element={<Login />} />
+        <Route
+          path="*"
+          element={
+            <MainLayout>
+              <NotFound />
+            </MainLayout>
+          }
+        />
       </Routes>
     </div>
   );

--- a/src/components/UI/NotFound.jsx
+++ b/src/components/UI/NotFound.jsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router';
+
+const NotFound = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[#f7f0fa] px-6 py-12 text-center">
+      <h1 className="text-[6rem] font-bebas text-msq-purple-rich leading-none tracking-wide">
+        404
+      </h1>
+      <span className="text-lg font-lato text-msq-purple-deep m-0 max-w-md">
+        Hey queen, you might be a little lost.
+      </span>
+      <span className="text-lg font-lato text-msq-purple-deep mb-4 max-w-md">
+        But your style journey doesn’t have to end here.
+      </span>
+      <p className="text-msq-gold font-[monotype-corsiva] italic mb-6">
+        Feel confident, beautiful, and uniquely you with Misqabbi.
+      </p>
+      <Link
+        to="/"
+        className="px-6 py-3 bg-msq-gold text-white font-lato uppercase tracking-wide hover:bg-[#cfb484] transition-colors"
+      >
+        Continue Shopping
+      </Link>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION

This PR introduces a placeholder 404 page and wires a catch-all route using React Router v7. The implementation ensures that any unmatched paths gracefully redirect users to a branded error page, improving navigation clarity and user experience.  

**Changes Included**  
- Added `NotFound.jsx` component with placeholder content  
- Updated `App.jsx` to include a wildcard route (`path="*"`)  
- Established routing structure for future layout and styling enhancements  

**Next Steps**  
- Style the 404 page to align with Misqabbi’s brand guidelines  