### PR TITLE
feat(cart): implement cart state hydration and persistence

### DIFF
--- a/src/contexts/cart/CartProvider.jsx
+++ b/src/contexts/cart/CartProvider.jsx
@@ -1,9 +1,19 @@
-import { useReducer } from 'react';
+import { useReducer, useEffect } from 'react';
 import { cartReducer, initialCartState } from './cartReducer';
 import { CartContextState, CartContextDispatch } from './cartContext';
+import { loadCartState, saveCartState } from '../../utils/cartPersistence';
+
+const getHydratedState = () => {
+  const persistedCartState = loadCartState();
+  return persistedCartState || initialCartState;
+};
 
 export const CartProvider = ({ children }) => {
-  const [state, dispatch] = useReducer(cartReducer, initialCartState);
+  const [state, dispatch] = useReducer(cartReducer, getHydratedState());
+
+  useEffect(() => {
+    saveCartState(state);
+  }, [state]);
 
   return (
     <CartContextState.Provider value={state}>

--- a/src/utils/cartPersistence.js
+++ b/src/utils/cartPersistence.js
@@ -1,0 +1,17 @@
+export const saveCartState = state => {
+  try {
+    localStorage.setItem('cartState', JSON.stringify(state));
+  } catch (error) {
+    console.error('Error saving cart state:', error);
+  }
+};
+
+export const loadCartState = () => {
+  try {
+    const persistedCartState = localStorage.getItem('cartState');
+    return persistedCartState ? JSON.parse(persistedCartState) : null;
+  } catch (error) {
+    console.error('Error loading cart state:', error);
+    return null;
+  }
+};


### PR DESCRIPTION
This pull request introduces cart state persistence using `localStorage`, ensuring that cart contents are retained across sessions and page reloads.

---

### **Key Changes**

- **Hydration Logic**:  
  `CartProvider` now initializes cart state using a `getHydratedState()` function, which loads persisted state via `loadCartState()` and falls back to `initialCartState` if none is found.

- **Persistence Hook**:  
  A `useEffect` hook in `CartProvider` watches for cart state changes and invokes `saveCartState()` to persist updates.

- **Utility Module**:  
  Added `cartPersistence.js` to encapsulate `saveCartState()` and `loadCartState()` functions, with error handling and fallback logic.

---

### **Impact**

- Cart contents now persist across browser sessions, improving user experience.
- Logic is modular, with separation of concerns between context, reducer, and persistence.

---

### **Next Steps**

- Implement cart clearing logic post-checkout to reset both context and persisted state.