### PR TITLE
Fix: Transform productId and enable credentials for CORS compliance

### DIFF
--- a/src/api/products.js
+++ b/src/api/products.js
@@ -4,7 +4,9 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api/v1';
 
 const fetchPaginatedProducts = async (page = 1, limit = 6) => {
   try {
-    const response = await axios.get(`${API_URL}/products?page=${page}&limit=${limit}`);
+    const response = await axios.get(`${API_URL}/products?page=${page}&limit=${limit}`, {
+      withCredentials: true,
+    });
     if (!response.data.success) throw new Error('Failed to fetch products');
     return response.data;
   } catch (error) {
@@ -15,7 +17,7 @@ const fetchPaginatedProducts = async (page = 1, limit = 6) => {
 
 const fetchProductBySlug = async slug => {
   try {
-    const response = await axios.get(`${API_URL}/products/${slug}`);
+    const response = await axios.get(`${API_URL}/products/${slug}`, { withCredentials: true });
     return response.data.data;
   } catch (error) {
     console.error('Error fetching product:', error);

--- a/src/contexts/favorites/favoritesReducer.js
+++ b/src/contexts/favorites/favoritesReducer.js
@@ -69,7 +69,12 @@ export const favoritesReducer = (state, action) => {
     case FAVORITES_ACTION_TYPES.SET_FAVORITES: {
       const favoritesMap = {};
       payload.forEach(favorite => {
-        favoritesMap[favorite.id] = favorite;
+        // Transform productId to id for consistency
+        const favoriteWithId = {
+          ...favorite,
+          id: favorite.productId,
+        };
+        favoritesMap[favorite.productId] = favoriteWithId;
       });
 
       return {


### PR DESCRIPTION
### Problem  
 Authenticated users saw only one favorite item in the drawer due to incorrect key mapping. Additionally, public requests to `/products` began failing with CORS errors once credentialed requests were introduced elsewhere in the app.

### Root Cause  
 - Favorites reducer was using `favorite.id` instead of `favorite.productId`, causing key collisions.  
 - Axios requests to `/favorites` used `withCredentials: true`, triggering credentialed CORS enforcement.  
 - Subsequent requests to `/products` returned `304 Not Modified` without CORS headers, leading to browser rejection.

### Solution  
 - Transformed `productId` to `id` in favorites reducer for consistent keying.  
 - Updated Axios requests to `/products` to include `withCredentials: true`, ensuring CORS headers are preserved even on cached responses.

### Changes Made  
 - Modified `SET_FAVORITES` case in `favoritesReducer.js` to remap `productId` → `id`.  
 - Updated Axios calls to `/products` to include `withCredentials: true`.

 These changes restore correct rendering of favorites and resolve CORS header omissions on public product requests.
