### PR TITLE
Feature/landing page links

### DIFF
--- a/src/components/landingpage/CategoryList.jsx
+++ b/src/components/landingpage/CategoryList.jsx
@@ -1,32 +1,46 @@
 import { useEffect, useRef, useState } from 'react';
+
+import { Link } from 'react-router';
+
 import CategoryCard from './CategoryCard';
 
 // Placeholder data
 const categories = [
   {
-    name: 'Jean',
-    image:
-      'https://images.unsplash.com/photo-1714729382668-7bc3bb261662?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    name: 'T-Shirt',
-    image:
-      'https://plus.unsplash.com/premium_photo-1689536143095-eaa89c407aa7?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    name: 'Gown',
-    image:
-      'https://images.unsplash.com/photo-1752836094974-630711fb07c7?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    name: 'Lace',
+    name: 'Dresses',
+    value: 'dresses',
     image:
       'https://images.unsplash.com/photo-1631233999975-3d559f0526e1?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
   {
-    name: 'Swimsuit',
+    name: 'Dungarees',
+    value: 'dungarees',
     image:
       'https://plus.unsplash.com/premium_photo-1671748710834-fd02d65ca400?q=80&w=626&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    name: 'Pants',
+    value: 'pants',
+    image:
+      'https://images.unsplash.com/photo-1714729382668-7bc3bb261662?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    name: 'Shorts',
+    value: 'shorts',
+    image:
+      'https://plus.unsplash.com/premium_photo-1689536143095-eaa89c407aa7?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    name: 'Skirts',
+    value: 'skirts',
+    image:
+      'https://images.unsplash.com/photo-1752836094974-630711fb07c7?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    name: 'Tops',
+    value: 'tops',
+    image:
+      'https://plus.unsplash.com/premium_photo-1690820318448-f2f7e938cb58?q=80&w=687&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   },
 ];
 
@@ -92,7 +106,9 @@ function CategoryList() {
       <div className="flex py-2  mx-auto">
         {visibleCards.map((cat, idx) => (
           <div key={cat.name} ref={idx === 0 ? cardRef : null}>
-            <CategoryCard name={cat.name} image={cat.image} />
+            <Link to={`/shop?category=${cat.value}`}>
+              <CategoryCard name={cat.name} image={cat.image} />
+            </Link>
           </div>
         ))}
       </div>

--- a/src/components/landingpage/CtaSection.jsx
+++ b/src/components/landingpage/CtaSection.jsx
@@ -23,7 +23,14 @@ const CtaSection = () => {
   return (
     <section className="pb-10 w-full text-center">
       <h2 className="text-2xl md:text-3xl font-bebas tracking-wide text-msq-purple-rich mb-6">
-        FOLLOW US ON INSTAGRAM <span className="text-msq-purple-light">@MISQABBIGH</span>
+        <a
+          href="https://www.instagram.com/misqabbigh"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          FOLLOW US ON INSTAGRAM <span className="text-msq-purple-light">@MISQABBIGH</span>
+        </a>
       </h2>
 
       <CtaGrid images={images} />

--- a/src/components/landingpage/MsqButton.jsx
+++ b/src/components/landingpage/MsqButton.jsx
@@ -2,8 +2,7 @@ export default function MsqButton({ label, variant = 'gold', className = '', onC
   let variantClasses = '';
 
   if (variant === 'gold') {
-    variantClasses =
-      'text-msq-gold-light border-msq-gold-light hover:bg-msq-gold-light hover:text-white';
+    variantClasses = 'border-msq-gold-light bg-msq-gold-light text-white';
   } else if (variant === 'purple') {
     variantClasses = 'text-msq-purple border-msq-purple hover:bg-msq-purple hover:text-white';
   } else if (variant === 'purple-deep') {

--- a/src/components/landingpage/PreviewBanner.jsx
+++ b/src/components/landingpage/PreviewBanner.jsx
@@ -1,5 +1,8 @@
-import MsqButton from './MsqButton';
 import { useEffect, useState } from 'react';
+
+import { Link } from 'react-router';
+
+import MsqButton from './MsqButton';
 
 const PreviewBanner = () => {
   const [bgPosition, setBgPosition] = useState('center -100px');
@@ -27,7 +30,9 @@ const PreviewBanner = () => {
           <h1 className="text-[40px] md:text-[128px] font-lato leading-[71px] w-[350px] md:w-[854px]">
             NEW ARRIVAL
           </h1>
-          <MsqButton label="SHOP COLLECTION" variant="gold" className=" md:mt-12 " />
+          <Link to="/shop">
+            <MsqButton label="SHOP COLLECTION" variant="gold" className=" md:mt-12 " />
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/landingpage/PreviewSplit.jsx
+++ b/src/components/landingpage/PreviewSplit.jsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router';
+
 import MsqButton from './MsqButton';
 
 const PreviewSplit = () => {
@@ -9,13 +11,15 @@ const PreviewSplit = () => {
           className="relative w-full h-[422px] md:h-[400px] bg-cover bg-center"
           style={{
             backgroundImage:
-              "url('https://images.unsplash.com/photo-1728402525443-92839fc739ed?q=80&w=764&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D')",
+              "url('https://images.unsplash.com/photo-1756485161657-e005fc9e4393?q=80&w=708&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D')",
           }}
         >
           <div className="absolute bottom-5 inset-x-0 bg-opacity-30 flex items-center justify-center">
             <div className="text-center text-white md:space-y-3">
-              <h2 className="text-[38px] md:text-[64px] font-lato w-[254px]">DENIM</h2>
-              <MsqButton label="SHOP DENIM" variant="gold" />
+              <h2 className="text-[38px] md:text-[64px] font-lato w-[254px]">DRESSES</h2>
+              <Link to="/shop?category=dresses">
+                <MsqButton label="SHOP DRESSES" variant="gold" />
+              </Link>
             </div>
           </div>
         </div>
@@ -25,13 +29,15 @@ const PreviewSplit = () => {
           className="relative w-full h-[422px] md:h-[400px] bg-cover bg-center"
           style={{
             backgroundImage:
-              "url('https://images.unsplash.com/photo-1663044023009-cfdb6dd6b89c?q=80&w=707&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D')",
+              "url('https://images.unsplash.com/photo-1713845784488-f81dbf2b1e81?q=80&w=715&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D')",
           }}
         >
           <div className="absolute bottom-5 inset-x-0 bg-opacity-30 flex items-center justify-center">
             <div className="text-center text-white  md:space-y-3">
-              <h2 className="text-[38px] md:text-[64px] font-lato w-[254px]">ANKARA</h2>
-              <MsqButton label="SHOP ANKARA" variant="gold" />
+              <h2 className="text-[38px] md:text-[64px] font-lato w-[254px]">SKIRTS</h2>
+              <Link to="/shop?category=skirts">
+                <MsqButton label="SHOP SKIRTS" variant="gold" />
+              </Link>
             </div>
           </div>
         </div>

--- a/src/components/landingpage/Showcase.jsx
+++ b/src/components/landingpage/Showcase.jsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router';
+
 import MsqButton from './MsqButton';
 import CategoryList from './CategoryList';
 import TrendingCollection from './TrendingCollection';
@@ -15,11 +17,13 @@ const Showcase = () => {
       </div>
 
       <div className="flex justify-center mt-[29pt] md:mt-[59px]">
-        <MsqButton
-          label="VIEW THE COLLECTION"
-          variant="gold"
-          className="text-[16px] md:text-[20px]"
-        />
+        <Link to="/shop">
+          <MsqButton
+            label="VIEW THE COLLECTION"
+            variant="gold"
+            className="text-[16px] md:text-[20px]"
+          />
+        </Link>
       </div>
     </section>
   );


### PR DESCRIPTION
### Summary
Enable category-driven navigation from the landing page and ensure the shop page immediately filters and fetches products using URL parameters on first render.

### Changes
- Landing page
  - Wrap category cards with links to `/shop?category=<value>` in `src/components/landingpage/CategoryList.jsx`.
- Shop page
  - Initialize catalog search state from URL on mount in `src/pages/ProductList.jsx` by reading `q`, `minPrice`, `maxPrice`, `category`, and `sort`, then dispatching `setSearchFromURL`.
  - Prevent premature initial fetch by gating the fetch effect behind `isInitialSearchSynced`, ensuring the first request includes the correct category.