### PR TITLE
Fix/landing page layout

### DIFF
--- a/src/components/landingpage/CategoryList.jsx
+++ b/src/components/landingpage/CategoryList.jsx
@@ -86,7 +86,10 @@ function CategoryList() {
   };
 
   return (
-    <div ref={containerRef} className="relative w-full flex items-center justify-center ">
+    <div
+      ref={containerRef}
+      className="relative w-full flex items-center justify-center px-12 sm:px-4"
+    >
       {/* Hidden card for measurement */}
       <div className="absolute opacity-0 pointer-events-none" ref={cardRef}>
         <CategoryCard name={categories[0].name} image={categories[0].image} />
@@ -94,7 +97,7 @@ function CategoryList() {
 
       {/* Left arrow */}
       <button
-        className={`sm:hidden z-10 rounded-full shadow p-2 -ml-3 ${isLeftDisabled ? 'opacity-50 cursor-not-allowed' : 'bg-white'}`}
+        className={`sm:hidden z-10 rounded-full shadow p-2 absolute left-2 top-2/3 -translate-y-1/2 ${isLeftDisabled ? 'opacity-50 cursor-not-allowed' : 'bg-white'}`}
         onClick={() => scroll('left')}
         disabled={isLeftDisabled}
       >
@@ -103,7 +106,7 @@ function CategoryList() {
         </svg>
       </button>
 
-      <div className="flex py-2  mx-auto">
+      <div className="flex py-2 mx-auto">
         {visibleCards.map((cat, idx) => (
           <div key={cat.name} ref={idx === 0 ? cardRef : null}>
             <Link to={`/shop?category=${cat.value}`}>
@@ -115,7 +118,7 @@ function CategoryList() {
 
       {/* Right arrow */}
       <button
-        className={`sm:hidden z-10 rounded-full shadow p-2 -mr-3 ${isRightDisabled ? 'opacity-50 cursor-not-allowed' : 'bg-white'}`}
+        className={`sm:hidden z-10 rounded-full shadow p-2 absolute right-2 top-2/3 -translate-y-1/2 ${isRightDisabled ? 'opacity-50 cursor-not-allowed' : 'bg-white'}`}
         onClick={() => scroll('right')}
         disabled={isRightDisabled}
       >

--- a/src/components/landingpage/HeroDesktop.jsx
+++ b/src/components/landingpage/HeroDesktop.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router';
 
 const HeroDesktop = () => (
   <section
-    className="w-full h-[600px] max-w-screen-2xl mx-auto md:h-[700px] bg-center bg-cover"
+    className="w-full h-[600px] max-w-screen-6xl mx-auto md:h-[700px] bg-center bg-cover"
     style={{
       backgroundImage:
         "url('https://images.unsplash.com/photo-1546536133-d1b07a9c768e?q=80&w=986&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D')",

--- a/src/components/landingpage/SectionWrapper.jsx
+++ b/src/components/landingpage/SectionWrapper.jsx
@@ -1,5 +1,5 @@
 const SectionWrapper = ({ children }) => (
-  <div className="w-full max-w-screen-2xl mx-auto px-4">{children}</div>
+  <div className="w-full max-w-[1707px] mx-auto px-4">{children}</div>
 );
 
 export default SectionWrapper;


### PR DESCRIPTION
**Changes:**
- Updated SectionWrapper to use custom max-width of 1707px instead of max-w-screen-3xl to prevent full-screen width on larger monitors
- Improved CategoryList mobile navigation by adding horizontal padding (px-12) to ensure arrow buttons remain visible on smaller screens
- Repositioned navigation arrows to be vertically centered between category images and text using top-2/3 positioning

**Impact:**
- Navigation arrows are now consistently visible across all mobile screen sizes
- Better user experience for browsing categories on mobile devices