### PR TITLE
Feature/guest checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22] # Ensure your matrix versions are compatible with your project
+        node-version: [20, 22]
 
     steps:
       - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22] # Ensure your matrix versions are compatible with your project
+        node-version: [20, 22]
 
     steps:
       - name: Checkout code
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22] # Ensure your matrix versions are compatible with your project
+        node-version: [20, 22]
 
     steps:
       - name: Checkout code

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,11 +64,9 @@ const App = () => {
           path="/orders/:id"
           element={
             <MainLayout>
-              <AuthBoundaryModal>
-                <Suspense fallback={<PageLoader />}>
-                  <OrderDetails />
-                </Suspense>
-              </AuthBoundaryModal>
+              <Suspense fallback={<PageLoader />}>
+                <OrderDetails />
+              </Suspense>
             </MainLayout>
           }
         ></Route>
@@ -76,11 +74,9 @@ const App = () => {
           path="/orders"
           element={
             <MainLayout>
-              <AuthBoundaryModal>
-                <Suspense fallback={<PageLoader />}>
-                  <Orders />
-                </Suspense>
-              </AuthBoundaryModal>
+              <Suspense fallback={<PageLoader />}>
+                <Orders />
+              </Suspense>
             </MainLayout>
           }
         ></Route>
@@ -174,11 +170,9 @@ const App = () => {
           path="/checkout"
           element={
             <MainLayout>
-              <AuthBoundaryModal>
-                <Suspense fallback={<PageLoader />}>
-                  <Checkout />
-                </Suspense>
-              </AuthBoundaryModal>
+              <Suspense fallback={<PageLoader />}>
+                <Checkout />
+              </Suspense>
             </MainLayout>
           }
         ></Route>

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -25,6 +25,31 @@ const fetchAuthenticatedUser = async () => {
   }
 };
 
+const createGuestSession = async () => {
+  try {
+    const response = await axios.post(
+      `${API_URL}/auth/guest/session`,
+      {},
+      { withCredentials: true }
+    );
+    const { success, message, data } = response.data;
+
+    if (success && data?.guestId) {
+      return { guestId: data.guestId, message };
+    }
+
+    throw new Error(message || 'Failed to create guest session');
+  } catch (error) {
+    console.error('Error creating guest session:', error);
+    const msg =
+      error.response?.data?.message ||
+      error.response?.data?.error ||
+      error.message ||
+      'Failed to create guest session';
+    throw new Error(msg);
+  }
+};
+
 const logoutUser = async () => {
   try {
     const response = await axios.post(`${API_URL}/auth/logout`, {}, { withCredentials: true });
@@ -124,6 +149,7 @@ const resetPassword = async (userId, token, newPassword) => {
 export {
   signInWithGoogleRedirect,
   fetchAuthenticatedUser,
+  createGuestSession,
   logoutUser,
   updateUserProfile,
   requestPasswordReset,

--- a/src/api/payments.js
+++ b/src/api/payments.js
@@ -7,9 +7,19 @@ const verifyPayment = async reference => {
     const res = await axios.get(`${API_URL}/payment/verify/${reference}`, {
       withCredentials: true,
     });
-    return res.data; // expects { success, data: { order, ... } }
+    const body = res.data;
+    if (!body?.success) {
+      const msg = body?.error || body?.message || 'Payment verification failed';
+      throw new Error(msg);
+    }
+    return body;
   } catch (error) {
     console.error('Error verifying payment:', error);
+    if (error.response?.data) {
+      const d = error.response.data;
+      const msg = d.error || d.message || error.message;
+      throw new Error(msg);
+    }
     throw error;
   }
 };

--- a/src/components/auth/AuthActionModal.jsx
+++ b/src/components/auth/AuthActionModal.jsx
@@ -24,9 +24,9 @@ const AuthActionModal = ({
         };
       case 'checkout':
         return {
-          heading: "Let's wrap this up beautifully 💫",
+          heading: 'Checkout as a guest or with an account',
           message:
-            "To complete your order and make it official, you'll need to sign in. It's quick, secure, and ensures your goodies get to you without a hitch.",
+            'You can complete your order without signing in. Create an account or log in to save your details and keep all orders in one place.',
           primaryButton: 'Log In',
           secondaryButton: 'Create Account',
           tertiaryButton: 'Maybe Later',

--- a/src/components/cart/CartDrawer.jsx
+++ b/src/components/cart/CartDrawer.jsx
@@ -2,7 +2,6 @@ import CartItem from './CartItem';
 import CartSummary from './CartSummary';
 import EmptyCartState from './EmptyCartState';
 import CartDrawerHeader from './CartDrawerHeader';
-import AuthActionModal from '../auth/AuthActionModal';
 import useCartDrawer from '../../hooks/useCartDrawer';
 
 const CartDrawer = ({ isOpen, onClose }) => {
@@ -14,9 +13,6 @@ const CartDrawer = ({ isOpen, onClose }) => {
     handleBackdropClick,
     handleClearCart,
     handleCheckout,
-    isModalOpen,
-    modalContext,
-    closeModal,
   } = useCartDrawer(isOpen, onClose);
 
   return (
@@ -70,9 +66,6 @@ const CartDrawer = ({ isOpen, onClose }) => {
           />
         )}
       </div>
-
-      {/* Auth Action Modal */}
-      <AuthActionModal isOpen={isModalOpen} onClose={closeModal} context={modalContext} />
     </>
   );
 };

--- a/src/components/layout/navigation/MobileMenu.jsx
+++ b/src/components/layout/navigation/MobileMenu.jsx
@@ -132,6 +132,21 @@ const MobileMenu = ({ isOpen, onClose }) => {
             <>
               {/* Guest User Section */}
               <div className="space-y-3">
+                <Link
+                  to="/orders"
+                  onClick={onClose}
+                  ref={firstFocusableRef}
+                  className="flex items-center gap-3 p-3 rounded-lg bg-gray-50 hover:bg-gray-100 transition-colors duration-200 text-gray-900"
+                >
+                  <div className="p-2 bg-msq-purple-rich text-white rounded-full">
+                    <PackageCheck size={20} />
+                  </div>
+                  <div>
+                    <div className="font-medium text-msq-purple-rich">My Orders</div>
+                    <div className="text-sm text-gray-500">Order history for this browser</div>
+                  </div>
+                </Link>
+
                 <div className="text-center py-4">
                   <div className="text-gray-600 mb-4">Welcome to Misqabbi</div>
                   <div className="space-y-3">
@@ -142,7 +157,6 @@ const MobileMenu = ({ isOpen, onClose }) => {
                     <Link
                       to="/register"
                       onClick={onClose}
-                      ref={firstFocusableRef}
                       className="block w-full text-center p-3 border border-msq-purple-rich text-msq-purple-rich rounded-lg hover:bg-msq-purple-rich hover:text-white transition-colors duration-200"
                     >
                       Create Account

--- a/src/components/layout/navigation/ProfileDropdown.jsx
+++ b/src/components/layout/navigation/ProfileDropdown.jsx
@@ -134,6 +134,21 @@ const ProfileDropdown = ({ className = '' }) => {
                     </div>
                   </Link>
 
+                  <Link
+                    to="/orders"
+                    onClick={closeDropdown}
+                    className="flex items-center gap-3 p-3 mx-2 rounded-lg bg-gray-50 hover:bg-gray-100 transition-colors duration-200 text-gray-900"
+                    role="menuitem"
+                  >
+                    <div className="p-2 bg-msq-purple-rich text-white rounded-full">
+                      <PackageCheck size={16} />
+                    </div>
+                    <div>
+                      <div className="font-medium text-sm text-msq-purple-rich">My Orders</div>
+                      <div className="text-xs text-gray-500">Order history for this browser</div>
+                    </div>
+                  </Link>
+
                   <div className="px-2">
                     <LoginButton
                       className="w-full justify-center p-3 mb-2 bg-msq-purple-rich text-white rounded-lg hover:opacity-70 transition-colors duration-200"

--- a/src/hooks/useCartDrawer.js
+++ b/src/hooks/useCartDrawer.js
@@ -7,13 +7,10 @@ import {
   getCartSubtotal,
 } from '../contexts/cart/cartSelectors';
 import { clearCart } from '../contexts/cart/cartActions';
-import useAuthAction from './useAuthAction';
-
 const useCartDrawer = (isOpen, onClose) => {
   const cartState = useCartState();
   const dispatch = useCartDispatch();
   const navigate = useNavigate();
-  const { requireAuth, isModalOpen, modalContext, closeModal } = useAuthAction();
   const [isAnimating, setIsAnimating] = useState(false);
 
   // Derived state
@@ -50,11 +47,7 @@ const useCartDrawer = (isOpen, onClose) => {
 
   const handleCheckout = () => {
     onClose(); // Close the drawer first
-
-    // Check authentication
-    if (!requireAuth(() => navigate('/checkout'), 'checkout', 1000)) {
-      return; // Auth modal will be shown, don't proceed
-    }
+    navigate('/checkout');
   };
 
   return {
@@ -68,11 +61,6 @@ const useCartDrawer = (isOpen, onClose) => {
     handleBackdropClick,
     handleClearCart,
     handleCheckout,
-
-    // Auth Modal
-    isModalOpen,
-    modalContext,
-    closeModal,
   };
 };
 

--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -6,6 +6,7 @@ import { useCartState } from '../contexts/cart/useCart';
 import { getCartItems } from '../contexts/cart/cartSelectors';
 
 import { createOrder } from '../api/orders';
+import { createGuestSession } from '../api/auth';
 import { showErrorToast } from '../utils/showToast';
 
 import CheckoutHeader from '../components/checkout/CheckoutHeader';
@@ -16,7 +17,7 @@ import SEO from '../components/SEO';
 
 const Checkout = () => {
   const navigate = useNavigate();
-  const { currentUser } = useAuthState();
+  const { currentUser, isAuthenticated } = useAuthState();
   const cartState = useCartState();
 
   const cartItems = getCartItems(cartState);
@@ -36,6 +37,10 @@ const Checkout = () => {
     setIsLoading(true);
 
     try {
+      if (!isAuthenticated) {
+        await createGuestSession();
+      }
+
       // Prepare order data
       const orderData = {
         items: cartItems.map(item => ({
@@ -69,7 +74,12 @@ const Checkout = () => {
         throw new Error('Failed to create order');
       }
     } catch (error) {
-      showErrorToast('Failed to place order.  ' + error.response.data.message);
+      const message =
+        error?.response?.data?.message ||
+        error?.response?.data?.error ||
+        error?.message ||
+        'Unknown error';
+      showErrorToast(`Failed to place order. ${message}`);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/PaymentCallback.jsx
+++ b/src/pages/PaymentCallback.jsx
@@ -21,7 +21,7 @@ const PaymentCallback = () => {
       try {
         const res = await verifyPayment(reference);
         const orderId = res?.data?.order;
-        if (!orderId) throw new Error('Order not found');
+        if (!orderId) throw new Error('Order not found after payment');
 
         // Clear cart after successful payment verification
         cartDispatch(clearCart());

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -86,11 +86,6 @@ function ProductDetails() {
   };
 
   const handleBuyNow = () => {
-    // Check authentication first
-    if (!requireAuth(() => {}, 'checkout')) {
-      return; // Auth modal will be shown, don't proceed
-    }
-
     // Validate custom size if enabled
     if (isCustomSizeEnabled && !isCustomSizeComplete(customMeasurements, product?.category)) {
       alert('Please complete all custom measurements');

--- a/src/pages/auth/AuthCallback.jsx
+++ b/src/pages/auth/AuthCallback.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { fetchAuthenticatedUser } from '../../api/auth';
 import { useAuthDispatch } from '../../contexts/auth/useAuth';
 import { setCurrentUser, setAuthRestored } from '../../contexts/auth/authActions';
@@ -8,6 +9,7 @@ import { LoadingSpinner } from '../../components/ui/LoadingSpinner.jsx';
 const AuthCallback = () => {
   const navigate = useNavigate();
   const dispatch = useAuthDispatch();
+  const queryClient = useQueryClient();
   const maxRetries = 3;
   const retryDelay = 500; // 500ms delay for Safari cookie availability
 
@@ -26,6 +28,7 @@ const AuthCallback = () => {
           // Successfully got user - set auth state
           dispatch(setCurrentUser(user));
           dispatch(setAuthRestored());
+          queryClient.invalidateQueries({ queryKey: ['orders'] });
 
           // Small delay to ensure state propagation, especially for Safari
           setTimeout(() => {


### PR DESCRIPTION
## Summary

Integrates the frontend with the backend guest principal model so unauthenticated shoppers can complete checkout and view their own orders in-session via `guest_token`, while preserving authenticated behavior and refreshing order data after OAuth login so merged guest orders appear immediately.

## Changes

### API

- Add `createGuestSession` calling `POST /auth/guest/session` with `withCredentials: true` to establish or refresh the guest cookie before unauthenticated checkout.

### Routing

- Remove `AuthBoundaryModal` from `/checkout`, `/orders`, and `/orders/:id` so guests are not redirected to `/shop`. Profile and admin routes remain protected.

### Checkout

- Before `POST /orders/checkout`, call the guest session endpoint when the user is not authenticated.
- Harden place-order error toasts when `error.response` is missing (network failures).

### Cart and product

- Remove `requireAuth` from the cart drawer checkout action and remove the auth modal from the cart drawer (no longer needed for checkout).
- Remove `requireAuth` from product Buy now so guests can reach checkout without the sign-in modal.

### Payments

- Treat payment verification responses with `success: false` and HTTP error bodies consistently, including backend access denied for a transaction reference, with clear error messages passed to the UI.

### Auth

- After successful OAuth callback hydration, invalidate TanStack Query `orders` queries so merged order history loads without a stale cache.
