### PR TITLE
Add bespoke request flow and landing CTA

### DIFF
--- a/docs/BESPOKE_BACKEND_GUIDE.md
+++ b/docs/BESPOKE_BACKEND_GUIDE.md
@@ -1,0 +1,104 @@
+# Backend brief: Bespoke request API
+
+## 1. Endpoint and method
+
+- **Method:** `POST`
+- **Path:** `/bespoke` (or `/api/v1/bespoke` if you use a versioned base like the rest of the app).
+- **Base URL:** Same as other APIs; frontend uses `VITE_API_URL` (e.g. `http://localhost:5000/api/v1`).
+- **Request format:** **`multipart/form-data`** so reference images can be received and included in the outgoing email (e.g. as attachments or linked after upload).
+- **Credentials:** Request must support **cookies** (`withCredentials: true`). Both **guests** and **logged-in users** can submit; no auth required for the route.
+
+---
+
+## 2. Request body (multipart/form-data)
+
+All fields are sent as form fields. The frontend will build a `FormData` and send it. Backend should accept:
+
+| Field name         | Type   | Required | Notes                                                                                                                                                                                                                            |
+| ------------------ | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fullName`         | string | Yes      | Guest: from form. Logged-in: from session.                                                                                                                                                                                       |
+| `email`            | string | Yes      | Valid email. Guest: from form. Logged-in: from session.                                                                                                                                                                          |
+| `phone`            | string | No       | Guest only when provided. Optional.                                                                                                                                                                                              |
+| `garmentType`      | string | No       | One of: `pants`, `skirts`, `dresses`, `dungarees`, or **`other`**. Empty string if not selected.                                                                                                                                 |
+| `garmentTypeOther` | string | No       | **Only when `garmentType` is `other`.** Free text for custom garment type (e.g. "Blouse", "Cape", "Jumpsuit").                                                                                                                   |
+| `measurements`     | string | No       | **Either:** (1) **JSON string** of an object when `garmentType` is a known category (see measurement keys below), or (2) **plain string** (free-form text) when `garmentType` is `other`. Omitted when no garment type selected. |
+| `styleNotes`       | string | No       | Free text.                                                                                                                                                                                                                       |
+| `description`      | string | Yes      | Min length 10. Sanitized on frontend.                                                                                                                                                                                            |
+| `referencePhotos`  | files  | No       | **Multiple file parts** with the same name (e.g. `referencePhotos` or `referencePhotos[]`). Images only. Max **5** files, each max **10 MB**.                                                                                    |
+
+---
+
+## 3. Garment type "Other"
+
+- When the user selects **Other**, the frontend sends:
+  - `garmentType`: `"other"`
+  - `garmentTypeOther`: optional string (e.g. "Blouse", "Cape") if the user filled it in.
+  - `measurements`: **plain string** (free-form), e.g. "bust 34, waist 28, length 42 (inches)" or any format the user prefers. Not JSON.
+
+- When `garmentType` is one of the known categories (`pants`, `skirts`, `dresses`, `dungarees`), `measurements` is a **JSON string** of an object (see below). `garmentTypeOther` is not sent.
+
+---
+
+## 4. Measurements (when garmentType is a known category)
+
+When `garmentType` is one of `pants`, `skirts`, `dresses`, `dungarees`, `measurements` is a **JSON string** of an object. All values are in **inches** (numbers or empty string). Keys depend on category:
+
+- **pants / skirts:** `waist`, `hip`, `length`
+- **dresses:** `bust`, `waist`, `hip`, `shoulderWidth`, `length`
+- **dungarees:** `bust`, `torsoLength`, `waist`, `hip`, `length`
+
+Example (dresses):  
+`{"bust":34,"waist":28,"hip":38,"shoulderWidth":14,"length":42}`
+
+Empty fields may be `""` or omitted.
+
+---
+
+## 5. Validation (align with frontend)
+
+- **fullName:** required, non-empty.
+- **email:** required, valid email format.
+- **description:** required, min length 10.
+- **referencePhotos:** optional; if present: max 5 files, each max 10 MB, image types only (e.g. image/\*).
+- **garmentType:** if present, must be one of: `pants`, `skirts`, `dresses`, `dungarees`, `other`; otherwise can be empty.
+- **garmentTypeOther:** optional; only meaningful when `garmentType === 'other'`.
+- **measurements:** if present and `garmentType` is not `other`, must be valid JSON; if `garmentType` is `other`, accept any non-empty string. Structure can be validated per category when `garmentType` is a known category.
+
+Return **4xx** with a clear `message` (or equivalent) so the frontend can show `error.message` in a toast.
+
+---
+
+## 6. Response
+
+**Success (e.g. 201 or 200):**
+
+- Body should include at least:  
+  `{ "success": true, "message": "…" }`
+- Frontend shows a success toast and clears the form; it does not depend on extra fields.
+
+**Error (4xx/5xx):**
+
+- Frontend shows `error.message` (e.g. from `response.data.message` or your standard error payload). Prefer a single, user-friendly string in a `message` field.
+
+---
+
+## 7. Business logic (no persistence)
+
+**Bespoke requests are not persisted on the backend.** They are turned into an email and sent to **the same recipient** as the contact form.
+
+- **Transform** the submission (fullName, email, phone, garmentType, garmentTypeOther, measurements, styleNotes, description) into an email.
+- **Send** that email to the **same recipient** used for contact form submissions.
+- **Reference photos:** include them in the email (e.g. as attachments, or upload to a provider like Cloudinary and put the image URLs in the email body). Do not persist the request or the images in your own storage beyond what is needed to send the email.
+
+---
+
+## 8. Frontend integration note
+
+The frontend will send a **multipart/form-data** request:
+
+1. Build a `FormData` and append each scalar field as a string.
+2. When `garmentType === 'other'`: append `garmentTypeOther` (if any) and append `measurements` as the **plain string** (free-form text).
+3. When `garmentType` is a known category: append `measurements` as **`JSON.stringify(measurementsObject)`**.
+4. Append each reference image file (same field name for multiple files).
+5. POST the `FormData` with **no** manual `Content-Type` (so the browser sets `multipart/form-data` with boundary).
+6. Use the same base URL and cookie credentials (`withCredentials: true`).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ const Favorites = lazy(() => import('./pages/Favorites'));
 const Register = lazy(() => import('./pages/Register'));
 const Login = lazy(() => import('./pages/Login'));
 const AuthCallback = lazy(() => import('./pages/auth/AuthCallback'));
+const Bespoke = lazy(() => import('./pages/Bespoke'));
 const CategoryPage = lazy(() => import('./pages/CategoryPage'));
 const ProductDetails = lazy(() => import('./pages/ProductDetails'));
 const Orders = lazy(() => import('./pages/Orders'));
@@ -96,6 +97,16 @@ const App = () => {
             </MainLayout>
           }
         ></Route>
+        <Route
+          path="/bespoke"
+          element={
+            <MainLayout>
+              <Suspense fallback={<PageLoader />}>
+                <Bespoke />
+              </Suspense>
+            </MainLayout>
+          }
+        />
         <Route
           path="/about-us"
           element={

--- a/src/api/bespoke.js
+++ b/src/api/bespoke.js
@@ -1,27 +1,62 @@
+import axios from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL;
+
 /**
- * Bespoke request API.
- * Currently mocked; replace with real POST (multipart/form-data) when backend is ready.
+ * Submit a bespoke request as multipart/form-data.
  * @param {Object} data - Form payload
- * @param {string} [data.fullName] - Guest full name
- * @param {string} [data.email] - Guest email
- * @param {string} [data.phone] - Guest phone (optional)
+ * @param {string} data.fullName - Full name (required)
+ * @param {string} data.email - Email (required)
+ * @param {string} [data.phone] - Phone (optional)
  * @param {string} [data.garmentType] - pants | skirts | dresses | dungarees | other
  * @param {string} [data.garmentTypeOther] - Custom garment type when garmentType is 'other'
- * @param {Object|string} [data.measurements] - When known category: object (e.g. { waist, hip, length }). When 'other': free-form string.
+ * @param {Object|string} [data.measurements] - When known category: object. When 'other': plain string.
  * @param {string} [data.styleNotes] - Style notes
  * @param {string} data.description - Required description
  * @param {File[]} [data.referencePhotos] - Reference image files
+ * @returns {Promise<{ success: true, message: string }>}
+ * @throws {Error} With server message on 4xx/5xx or 429
  */
 export const submitBespokeRequest = async data => {
-  // Mock: log payload for future backend integration
-  const payload = {
-    ...data,
-    referencePhotos: data.referencePhotos?.length ?? 0,
-  };
-  console.log('[bespoke] Mock submit payload:', payload);
+  const formData = new FormData();
+  formData.append('fullName', data.fullName ?? '');
+  formData.append('email', data.email ?? '');
+  if (data.phone) formData.append('phone', data.phone);
+  if (data.garmentType) formData.append('garmentType', data.garmentType);
+  if (data.garmentType === 'other' && data.garmentTypeOther) {
+    formData.append('garmentTypeOther', data.garmentTypeOther);
+  }
+  if (data.measurements !== undefined && data.measurements !== '') {
+    const measurementsValue =
+      typeof data.measurements === 'string' ? data.measurements : JSON.stringify(data.measurements);
+    formData.append('measurements', measurementsValue);
+  }
+  if (data.styleNotes) formData.append('styleNotes', data.styleNotes);
+  formData.append('description', data.description ?? '');
+  if (data.referencePhotos?.length) {
+    data.referencePhotos.forEach(file => formData.append('referencePhotos', file));
+  }
 
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 400));
+  try {
+    const response = await axios.post(`${API_URL}/bespoke`, formData, {
+      withCredentials: true,
+      // Do not set Content-Type; axios sets multipart/form-data with boundary for FormData
+    });
 
-  return { success: true, message: 'Request received. We will be in touch.' };
+    const resData = response.data;
+    if (response.status === 201 && resData?.success) {
+      return { success: true, message: resData.message ?? 'Bespoke form submitted successfully.' };
+    }
+    throw new Error(resData?.message ?? 'Something went wrong. Please try again.');
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const message =
+        error.response.data?.message ??
+        (error.response.status === 429
+          ? 'Too many submissions. Please try again later.'
+          : 'Something went wrong. Please try again.');
+      throw new Error(message);
+    }
+    throw error;
+  }
 };

--- a/src/api/bespoke.js
+++ b/src/api/bespoke.js
@@ -1,0 +1,27 @@
+/**
+ * Bespoke request API.
+ * Currently mocked; replace with real POST (multipart/form-data) when backend is ready.
+ * @param {Object} data - Form payload
+ * @param {string} [data.fullName] - Guest full name
+ * @param {string} [data.email] - Guest email
+ * @param {string} [data.phone] - Guest phone (optional)
+ * @param {string} [data.garmentType] - pants | skirts | dresses | dungarees | other
+ * @param {string} [data.garmentTypeOther] - Custom garment type when garmentType is 'other'
+ * @param {Object|string} [data.measurements] - When known category: object (e.g. { waist, hip, length }). When 'other': free-form string.
+ * @param {string} [data.styleNotes] - Style notes
+ * @param {string} data.description - Required description
+ * @param {File[]} [data.referencePhotos] - Reference image files
+ */
+export const submitBespokeRequest = async data => {
+  // Mock: log payload for future backend integration
+  const payload = {
+    ...data,
+    referencePhotos: data.referencePhotos?.length ?? 0,
+  };
+  console.log('[bespoke] Mock submit payload:', payload);
+
+  // Simulate network delay
+  await new Promise(resolve => setTimeout(resolve, 400));
+
+  return { success: true, message: 'Request received. We will be in touch.' };
+};

--- a/src/components/bespoke/BespokeIntro.jsx
+++ b/src/components/bespoke/BespokeIntro.jsx
@@ -1,15 +1,23 @@
+import { LoadStagger, StaggerItem } from '../ui/motion/MotionWrappers';
+
 const BespokeIntro = () => {
   return (
     <section className="w-full px-2 sm:px-3 lg:px-6 py-4 sm:py-6 lg:py-8 bg-gradient-to-b from-gray-50/30 to-white">
       <div className="max-w-6xl mx-auto">
-        <div className="text-center mb-4 sm:mb-6 lg:mb-8">
-          <h1 className="font-bebas text-2xl sm:text-3xl md:text-4xl lg:text-5xl text-msq-purple-rich uppercase tracking-wider mb-2 sm:mb-3 leading-tight">
+        <LoadStagger className="text-center mb-4 sm:mb-6 lg:mb-8">
+          <StaggerItem
+            as="h1"
+            className="font-bebas text-2xl sm:text-3xl md:text-4xl lg:text-5xl text-msq-purple-rich uppercase tracking-wider mb-2 sm:mb-3 leading-tight"
+          >
             Bespoke
-          </h1>
-          <p className="text-sm sm:text-base md:text-lg text-msq-purple-deep font-lato max-w-xl mx-auto leading-snug">
+          </StaggerItem>
+          <StaggerItem
+            as="p"
+            className="text-sm sm:text-base md:text-lg text-msq-purple-deep font-lato max-w-xl mx-auto leading-snug"
+          >
             Hey gorgeous, want something made just for you? Let's bring your style to life.
-          </p>
-        </div>
+          </StaggerItem>
+        </LoadStagger>
       </div>
     </section>
   );

--- a/src/components/bespoke/BespokeIntro.jsx
+++ b/src/components/bespoke/BespokeIntro.jsx
@@ -1,0 +1,18 @@
+const BespokeIntro = () => {
+  return (
+    <section className="w-full px-2 sm:px-3 lg:px-6 py-4 sm:py-6 lg:py-8 bg-gradient-to-b from-gray-50/30 to-white">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-4 sm:mb-6 lg:mb-8">
+          <h1 className="font-bebas text-2xl sm:text-3xl md:text-4xl lg:text-5xl text-msq-purple-rich uppercase tracking-wider mb-2 sm:mb-3 leading-tight">
+            Bespoke
+          </h1>
+          <p className="text-sm sm:text-base md:text-lg text-msq-purple-deep font-lato max-w-xl mx-auto leading-snug">
+            Hey gorgeous, want something made just for you? Let's bring your style to life.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BespokeIntro;

--- a/src/components/bespoke/BespokeRequestForm.jsx
+++ b/src/components/bespoke/BespokeRequestForm.jsx
@@ -1,0 +1,523 @@
+import { useState, useRef, useEffect } from 'react';
+import { User, Mail, Phone, Shirt, FileText, ImageIcon, X } from 'lucide-react';
+import { useAuthState } from '../../contexts/auth/useAuth';
+import { submitBespokeRequest } from '../../api/bespoke';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+import { isValidEmail } from '../../utils/validation';
+import {
+  sanitizeName,
+  sanitizeEmail,
+  sanitizeMessage,
+  sanitizeMeasurement,
+} from '../../utils/sanitization';
+import InputField from '../form/InputField';
+import PhoneNumberField from '../form/PhoneNumberField';
+import { CATEGORIES } from '../../constants/categories';
+import { getMeasurementConfig } from '../../constants/customSizeMeasurements';
+import { initializeMeasurements } from '../../utils/customSizeValidation';
+
+const MAX_PHOTOS = 5;
+const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
+// Garment type options: placeholder + established categories + Other
+const GARMENT_OPTIONS = [
+  { value: '', label: 'Select garment type' },
+  ...CATEGORIES.filter(c => c.value !== '').map(c => ({ value: c.value, label: c.label })),
+  { value: 'other', label: 'Other' },
+];
+
+const BespokeRequestForm = () => {
+  const { isAuthenticated, currentUser } = useAuthState();
+
+  const [formData, setFormData] = useState({
+    fullName: '',
+    email: '',
+    phone: '',
+    measurements: {},
+    garmentType: '',
+    garmentTypeOther: '',
+    measurementsOther: '',
+    styleNotes: '',
+    description: '',
+  });
+  const [referencePhotos, setReferencePhotos] = useState([]);
+  const [errors, setErrors] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const measurementConfig = getMeasurementConfig(formData.garmentType);
+
+  // Reset measurements when garment type changes so the right fields appear
+  useEffect(() => {
+    if (formData.garmentType && formData.garmentType !== 'other') {
+      setFormData(prev => ({
+        ...prev,
+        measurements: initializeMeasurements(formData.garmentType),
+        garmentTypeOther: '',
+        measurementsOther: '',
+      }));
+    } else if (formData.garmentType === 'other') {
+      setFormData(prev => ({
+        ...prev,
+        measurements: {},
+        measurementsOther: prev.measurementsOther ?? '',
+      }));
+    } else {
+      setFormData(prev => ({
+        ...prev,
+        measurements: {},
+        garmentTypeOther: '',
+        measurementsOther: '',
+      }));
+    }
+  }, [formData.garmentType]);
+
+  const handleInputChange = e => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+    if (errors[name]) {
+      setErrors(prev => {
+        const { [name]: _, ...rest } = prev;
+        return rest;
+      });
+    }
+  };
+
+  const handleMeasurementChange = (fieldKey, value) => {
+    const sanitized = sanitizeMeasurement(value);
+    const displayValue = value === '' ? '' : sanitized;
+    setFormData(prev => ({
+      ...prev,
+      measurements: {
+        ...prev.measurements,
+        [fieldKey]: displayValue,
+      },
+    }));
+    setErrors(prev => {
+      const { [fieldKey]: _, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  const validateForm = () => {
+    const newErrors = {};
+
+    if (!isAuthenticated) {
+      if (!formData.fullName?.trim()) newErrors.fullName = 'Name is required';
+      if (!formData.email?.trim()) {
+        newErrors.email = 'Email is required';
+      } else if (!isValidEmail(formData.email)) {
+        newErrors.email = 'Please enter a valid email address';
+      }
+    }
+
+    if (!formData.description?.trim()) {
+      newErrors.description = 'Description is required';
+    } else if (formData.description.trim().length < 10) {
+      newErrors.description = 'Description must be at least 10 characters';
+    }
+
+    if (referencePhotos.length > MAX_PHOTOS) {
+      newErrors.referencePhotos = `Maximum ${MAX_PHOTOS} photos allowed`;
+    }
+    const oversized = referencePhotos.find(f => f.size > MAX_FILE_SIZE_BYTES);
+    if (oversized) {
+      newErrors.referencePhotos = `Each file must be under ${MAX_FILE_SIZE_MB}MB`;
+    }
+
+    return newErrors;
+  };
+
+  const handleFileChange = e => {
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    const valid = files.filter(f => f.type.startsWith('image/') && f.size <= MAX_FILE_SIZE_BYTES);
+    setReferencePhotos(prev => {
+      const combined = [...prev, ...valid].slice(0, MAX_PHOTOS);
+      return combined;
+    });
+    if (errors.referencePhotos) {
+      setErrors(prev => {
+        const { referencePhotos: _, ...rest } = prev;
+        return rest;
+      });
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const removePhoto = index => {
+    setReferencePhotos(prev => prev.filter((_, i) => i !== index));
+    if (errors.referencePhotos) {
+      setErrors(prev => {
+        const { referencePhotos: _, ...rest } = prev;
+        return rest;
+      });
+    }
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const validationErrors = validateForm();
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const payload = {
+        garmentType: formData.garmentType || undefined,
+        garmentTypeOther:
+          formData.garmentType === 'other'
+            ? formData.garmentTypeOther?.trim() || undefined
+            : undefined,
+        measurements:
+          formData.garmentType === 'other'
+            ? formData.measurementsOther?.trim() || undefined
+            : formData.garmentType && measurementConfig
+              ? formData.measurements
+              : undefined,
+        styleNotes: formData.styleNotes?.trim() || undefined,
+        description: sanitizeMessage(formData.description),
+        referencePhotos,
+      };
+      if (!isAuthenticated) {
+        payload.fullName = sanitizeName(formData.fullName);
+        payload.email = sanitizeEmail(formData.email);
+        payload.phone = formData.phone?.trim() || undefined;
+      } else {
+        payload.fullName = currentUser?.displayName ?? '';
+        payload.email = currentUser?.email ?? '';
+      }
+
+      await submitBespokeRequest(payload);
+      showSuccessToast('Your bespoke request has been received. We will be in touch soon.');
+      setFormData({
+        fullName: '',
+        email: '',
+        phone: '',
+        measurements: {},
+        garmentType: '',
+        garmentTypeOther: '',
+        measurementsOther: '',
+        styleNotes: '',
+        description: '',
+      });
+      setReferencePhotos([]);
+      setErrors({});
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    } catch (error) {
+      showErrorToast(error.message || 'Something went wrong. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const customInputClasses =
+    'py-2 sm:py-2.5 text-sm border-gray-200 rounded-lg bg-gray-50/50 focus:bg-white focus:border-msq-purple-rich focus:ring-1 focus:ring-msq-purple-rich/20 text-gray-900 placeholder:text-gray-400';
+  const customTextareaClasses = `${customInputClasses} min-h-[80px] sm:min-h-[100px]`;
+
+  return (
+    <div className="w-full px-2 sm:px-3 lg:px-6 py-6 sm:py-8 lg:py-12 bg-gradient-to-b from-gray-50/40 to-white">
+      <div className="max-w-6xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 items-start">
+          {/* Form column: narrower form card, centered */}
+          <div className="lg:col-span-7 flex justify-center lg:justify-start">
+            <div className="w-full max-w-2xl bg-white rounded-lg sm:rounded-xl shadow-lg sm:shadow-xl p-4 sm:p-5 lg:p-6 border border-gray-100">
+              <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-5 text-left">
+                {isAuthenticated ? (
+                  <p className="text-sm text-gray-600 font-lato py-1">
+                    Submitting as{' '}
+                    <span className="font-medium text-msq-purple-rich">
+                      {currentUser?.displayName || currentUser?.email || 'you'}
+                    </span>
+                  </p>
+                ) : (
+                  <>
+                    <div className="group">
+                      <InputField
+                        label={
+                          <>
+                            Full name <span className="text-red-500">*</span>
+                          </>
+                        }
+                        type="text"
+                        name="fullName"
+                        value={formData.fullName}
+                        onChange={handleInputChange}
+                        placeholder="Your full name"
+                        icon={<User size={14} strokeWidth={1.5} className="sm:w-4 sm:h-4" />}
+                        iconPosition="left"
+                        error={errors.fullName}
+                        required
+                        sanitizeType="name"
+                        className={customInputClasses}
+                        labelClassName="text-xs font-medium text-gray-700 mb-1 sm:mb-1.5"
+                        aria-required="true"
+                        aria-invalid={errors.fullName ? 'true' : 'false'}
+                      />
+                    </div>
+                    <div className="group">
+                      <InputField
+                        label={
+                          <>
+                            Email <span className="text-red-500">*</span>
+                          </>
+                        }
+                        type="email"
+                        name="email"
+                        value={formData.email}
+                        onChange={handleInputChange}
+                        placeholder="your.email@example.com"
+                        icon={<Mail size={14} strokeWidth={1.5} className="sm:w-4 sm:h-4" />}
+                        iconPosition="left"
+                        error={errors.email}
+                        required
+                        sanitizeType="email"
+                        className={customInputClasses}
+                        labelClassName="text-xs font-medium text-gray-700 mb-1 sm:mb-1.5"
+                        aria-required="true"
+                        aria-invalid={errors.email ? 'true' : 'false'}
+                      />
+                    </div>
+                    <div className="group">
+                      <PhoneNumberField
+                        label="Phone (optional)"
+                        name="phone"
+                        value={formData.phone}
+                        onChange={handleInputChange}
+                        placeholder="241234567"
+                        icon={<Phone size={14} strokeWidth={1.5} className="sm:w-4 sm:h-4" />}
+                        error={errors.phone}
+                        className={customInputClasses}
+                      />
+                    </div>
+                  </>
+                )}
+
+                <div className="space-y-2">
+                  <label className="block text-xs font-medium text-gray-700 mb-1 sm:mb-1.5">
+                    Garment type (optional)
+                  </label>
+                  <select
+                    name="garmentType"
+                    value={formData.garmentType}
+                    onChange={handleInputChange}
+                    className={`w-full py-2 sm:py-2.5 px-3 text-sm border rounded-lg font-lato text-gray-900 bg-gray-50/50 focus:bg-white focus:border-msq-purple-rich focus:ring-1 focus:ring-msq-purple-rich/20 ${errors.garmentType ? 'border-red-500' : 'border-gray-200'}`}
+                  >
+                    {GARMENT_OPTIONS.map(opt => (
+                      <option key={opt.value || 'empty'} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {formData.garmentType === 'other' && (
+                  <div className="group">
+                    <InputField
+                      label="Please specify garment type (optional)"
+                      type="text"
+                      name="garmentTypeOther"
+                      value={formData.garmentTypeOther}
+                      onChange={handleInputChange}
+                      placeholder="e.g. Blouse, Cape, Jumpsuit"
+                      className={customInputClasses}
+                      labelClassName="text-xs font-medium text-gray-700 mb-1 sm:mb-1.5"
+                    />
+                  </div>
+                )}
+
+                <div className="group">
+                  <div className="flex items-baseline gap-2 mb-2">
+                    <label className="block text-xs font-medium text-gray-700">
+                      Measurements (optional)
+                    </label>
+                    {formData.garmentType !== 'other' && measurementConfig && (
+                      <span className="text-xs text-gray-500">Inches</span>
+                    )}
+                  </div>
+                  {!formData.garmentType ? (
+                    <p className="text-xs text-gray-500 py-2 font-lato">
+                      Select a garment type above to enter measurements.
+                    </p>
+                  ) : formData.garmentType === 'other' ? (
+                    <InputField
+                      label=""
+                      name="measurementsOther"
+                      value={formData.measurementsOther}
+                      onChange={handleInputChange}
+                      placeholder="e.g. bust 34, waist 28, length 42 (inches) or your preferred format"
+                      as="textarea"
+                      sanitizeType="message"
+                      className={customTextareaClasses}
+                    />
+                  ) : measurementConfig ? (
+                    <div className="border border-gray-200 rounded-lg p-3 sm:p-4 bg-gray-50/50">
+                      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-3">
+                        {measurementConfig.fields.map(field => (
+                          <div key={field.key} className="flex flex-col">
+                            <label
+                              htmlFor={`measurement-${field.key}`}
+                              className="text-xs text-gray-600 mb-1 font-medium"
+                            >
+                              {field.label}
+                            </label>
+                            <input
+                              id={`measurement-${field.key}`}
+                              type="number"
+                              value={formData.measurements[field.key] ?? ''}
+                              onChange={e => handleMeasurementChange(field.key, e.target.value)}
+                              className="w-full px-2 sm:px-3 py-1.5 sm:py-2 border border-gray-200 rounded-lg text-xs sm:text-sm text-gray-900 focus:ring-1 focus:ring-msq-purple-rich focus:border-msq-purple-rich font-lato bg-white"
+                              placeholder={field.label}
+                              min={field.min}
+                              max={field.max}
+                              step="0.1"
+                              aria-label={field.label}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-gray-500 py-2 font-lato">
+                      Add any measurement notes in the description below.
+                    </p>
+                  )}
+                </div>
+
+                <div className="group">
+                  <InputField
+                    label="Style notes (optional)"
+                    name="styleNotes"
+                    value={formData.styleNotes}
+                    onChange={handleInputChange}
+                    placeholder="Fabric, colour, fit preferences..."
+                    icon={<Shirt size={14} strokeWidth={1.5} className="sm:w-4 sm:h-4" />}
+                    iconPosition="left"
+                    className={customInputClasses}
+                    labelClassName="text-xs font-medium text-gray-700 mb-1 sm:mb-1.5"
+                  />
+                </div>
+
+                <div className="group">
+                  <InputField
+                    label={
+                      <>
+                        Describe what you want created or re-created{' '}
+                        <span className="text-red-500">*</span>
+                      </>
+                    }
+                    name="description"
+                    value={formData.description}
+                    onChange={handleInputChange}
+                    placeholder="Tell us your vision in detail..."
+                    icon={<FileText size={14} strokeWidth={1.5} className="sm:w-4 sm:h-4" />}
+                    iconPosition="left"
+                    as="textarea"
+                    sanitizeType="description"
+                    error={errors.description}
+                    required
+                    className={customTextareaClasses}
+                    labelClassName="text-xs font-medium text-gray-700 mb-1 sm:mb-1.5"
+                    aria-required="true"
+                    aria-invalid={errors.description ? 'true' : 'false'}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label className="block text-xs font-medium text-gray-700 mb-1 sm:mb-1.5">
+                    Reference photos (optional, max {MAX_PHOTOS}, 10MB each)
+                  </label>
+                  <div className="relative">
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*"
+                      multiple
+                      onChange={handleFileChange}
+                      className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
+                      aria-label="Upload reference photos"
+                    />
+                    <div
+                      className={`flex flex-col items-center justify-center px-4 py-6 border-2 border-dashed rounded-lg transition-colors ${
+                        errors.referencePhotos
+                          ? 'border-red-300 bg-red-50'
+                          : 'border-gray-300 bg-gray-50 hover:bg-gray-100 hover:border-msq-purple-rich'
+                      }`}
+                    >
+                      <ImageIcon className="w-8 h-8 text-gray-400 mb-2" strokeWidth={1.5} />
+                      <p className="text-sm text-gray-600">
+                        <span className="font-medium text-msq-purple-rich">Click to upload</span> or
+                        drag and drop
+                      </p>
+                      <p className="text-xs text-gray-500 mt-0.5">PNG, JPG up to 10MB</p>
+                    </div>
+                  </div>
+                  {errors.referencePhotos && (
+                    <p className="text-red-500 text-sm font-lato">{errors.referencePhotos}</p>
+                  )}
+                  {referencePhotos.length > 0 && (
+                    <ul className="mt-2 space-y-1">
+                      {referencePhotos.map((file, index) => (
+                        <li
+                          key={`${file.name}-${index}`}
+                          className="flex items-center justify-between text-sm text-gray-700 bg-gray-50 rounded px-2 py-1.5"
+                        >
+                          <span className="truncate flex-1">{file.name}</span>
+                          <button
+                            type="button"
+                            onClick={() => removePhoto(index)}
+                            className="p-1 text-gray-500 hover:text-red-600 rounded transition-colors"
+                            aria-label={`Remove ${file.name}`}
+                          >
+                            <X size={16} />
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                <div className="pt-2">
+                  <button
+                    type="submit"
+                    disabled={isLoading}
+                    className="w-full cursor-pointer bg-gradient-to-r from-msq-purple-rich to-msq-purple text-white py-2 sm:py-2.5 lg:py-3 px-5 sm:px-6 rounded-lg font-lato font-semibold text-sm tracking-wide hover:shadow-lg hover:shadow-msq-purple-rich/30 hover:scale-[1.01] active:scale-[0.99] transition-all duration-300 disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none group relative overflow-hidden"
+                    aria-label={isLoading ? 'Submitting...' : 'Submit request'}
+                  >
+                    <span className="relative z-10 flex items-center justify-center gap-1.5">
+                      {isLoading ? (
+                        <>
+                          <div className="w-3.5 h-3.5 sm:w-4 sm:h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                          <span>Submitting...</span>
+                        </>
+                      ) : (
+                        'Submit request'
+                      )}
+                    </span>
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          {/* Side panel: tagline and short guidance */}
+          <div className="lg:col-span-5">
+            <div className="bg-gradient-to-br from-msq-purple-rich to-msq-purple-deep rounded-lg sm:rounded-xl shadow-xl p-4 sm:p-5 lg:p-6 text-white border border-msq-purple-rich/20 lg:sticky lg:top-24">
+              <p className="text-white/90 font-lato text-sm sm:text-base leading-relaxed">
+                Share your measurements, style preferences, and reference photos. We’ll follow up to
+                bring your vision to life.
+              </p>
+              <p className="mt-4 sm:mt-5 pt-3 sm:pt-4 border-t border-white/20 text-white/80 italic font-lato text-sm">
+                Made with love, made for you.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BespokeRequestForm;

--- a/src/components/bespoke/BespokeRequestForm.jsx
+++ b/src/components/bespoke/BespokeRequestForm.jsx
@@ -190,8 +190,8 @@ const BespokeRequestForm = () => {
         payload.email = currentUser?.email ?? '';
       }
 
-      await submitBespokeRequest(payload);
-      showSuccessToast('Your bespoke request has been received. We will be in touch soon.');
+      const result = await submitBespokeRequest(payload);
+      showSuccessToast(result.message);
       setFormData({
         fullName: '',
         email: '',

--- a/src/components/bespoke/BespokeRequestForm.jsx
+++ b/src/components/bespoke/BespokeRequestForm.jsx
@@ -12,6 +12,8 @@ import {
 } from '../../utils/sanitization';
 import InputField from '../form/InputField';
 import PhoneNumberField from '../form/PhoneNumberField';
+import Button from '../ui/Button';
+import { StaggerGroup, StaggerItem } from '../ui/motion/MotionWrappers';
 import { CATEGORIES } from '../../constants/categories';
 import { getMeasurementConfig } from '../../constants/customSizeMeasurements';
 import { initializeMeasurements } from '../../utils/customSizeValidation';
@@ -220,9 +222,9 @@ const BespokeRequestForm = () => {
   return (
     <div className="w-full px-2 sm:px-3 lg:px-6 py-6 sm:py-8 lg:py-12 bg-gradient-to-b from-gray-50/40 to-white">
       <div className="max-w-6xl mx-auto">
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 items-start">
+        <StaggerGroup className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 items-start">
           {/* Form column: narrower form card, centered */}
-          <div className="lg:col-span-7 flex justify-center lg:justify-start">
+          <StaggerItem className="lg:col-span-7 flex justify-center lg:justify-start">
             <div className="w-full max-w-2xl bg-white rounded-lg sm:rounded-xl shadow-lg sm:shadow-xl p-4 sm:p-5 lg:p-6 border border-gray-100">
               <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-5 text-left">
                 {isAuthenticated ? (
@@ -480,30 +482,29 @@ const BespokeRequestForm = () => {
                 </div>
 
                 <div className="pt-2">
-                  <button
+                  <Button
                     type="submit"
                     disabled={isLoading}
-                    className="w-full cursor-pointer bg-gradient-to-r from-msq-purple-rich to-msq-purple text-white py-2 sm:py-2.5 lg:py-3 px-5 sm:px-6 rounded-lg font-lato font-semibold text-sm tracking-wide hover:shadow-lg hover:shadow-msq-purple-rich/30 hover:scale-[1.01] active:scale-[0.99] transition-all duration-300 disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none group relative overflow-hidden"
+                    variant="primarySlideWhite"
+                    className="w-full py-2 sm:py-2.5 lg:py-3 px-5 sm:px-6 rounded-lg font-lato font-semibold text-sm tracking-wide hover:shadow-lg hover:shadow-msq-purple-rich/30 hover:scale-[1.01] active:scale-[0.99] disabled:opacity-60 disabled:cursor-not-allowed disabled:pointer-events-none disabled:hover:scale-100 disabled:hover:shadow-none"
                     aria-label={isLoading ? 'Submitting...' : 'Submit request'}
                   >
-                    <span className="relative z-10 flex items-center justify-center gap-1.5">
-                      {isLoading ? (
-                        <>
-                          <div className="w-3.5 h-3.5 sm:w-4 sm:h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                          <span>Submitting...</span>
-                        </>
-                      ) : (
-                        'Submit request'
-                      )}
-                    </span>
-                  </button>
+                    {isLoading ? (
+                      <span className="flex items-center justify-center gap-1.5">
+                        <span className="w-3.5 h-3.5 sm:w-4 sm:h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                        <span>Submitting...</span>
+                      </span>
+                    ) : (
+                      'Submit request'
+                    )}
+                  </Button>
                 </div>
               </form>
             </div>
-          </div>
+          </StaggerItem>
 
           {/* Side panel: tagline and short guidance */}
-          <div className="lg:col-span-5">
+          <StaggerItem className="lg:col-span-5">
             <div className="bg-gradient-to-br from-msq-purple-rich to-msq-purple-deep rounded-lg sm:rounded-xl shadow-xl p-4 sm:p-5 lg:p-6 text-white border border-msq-purple-rich/20 lg:sticky lg:top-24">
               <p className="text-white/90 font-lato text-sm sm:text-base leading-relaxed">
                 Share your measurements, style preferences, and reference photos. We’ll follow up to
@@ -513,8 +514,8 @@ const BespokeRequestForm = () => {
                 Made with love, made for you.
               </p>
             </div>
-          </div>
-        </div>
+          </StaggerItem>
+        </StaggerGroup>
       </div>
     </div>
   );

--- a/src/components/form/PhoneNumberField.jsx
+++ b/src/components/form/PhoneNumberField.jsx
@@ -35,15 +35,14 @@ const PhoneNumberField = forwardRef(
             {label}
           </label>
         )}
-        <div className="flex">
-          <select
-            className="px-3 py-3 border border-gray-300 border-r-0 rounded-l-lg focus:ring-2 focus:ring-msq-purple-rich focus:border-transparent transition-colors duration-200 font-lato cursor-pointer bg-gray-50 text-gray-900"
-            value="+233"
-            disabled
+        <div className="flex items-stretch">
+          <div
+            className="flex items-center shrink-0 px-3 rounded-l-lg border border-r-0 border-gray-300 bg-gray-100 text-gray-500 font-lato text-sm select-none"
+            aria-hidden="true"
           >
-            <option value="+233">🇬🇭 +233</option>
-          </select>
-          <div className="relative flex-1">
+            +233
+          </div>
+          <div className="relative flex-1 min-w-0">
             <InputField
               ref={ref}
               type="tel"

--- a/src/components/landingpage/PreviewBanner.jsx
+++ b/src/components/landingpage/PreviewBanner.jsx
@@ -5,11 +5,11 @@ import { StaggerGroup, StaggerItem } from '../ui/motion/MotionWrappers';
 
 const PreviewBanner = () => {
   return (
-    <div className="relative w-full h-[120px] md:h-[450px] overflow-hidden">
+    <div className="group relative w-full h-[120px] md:h-[450px] overflow-hidden">
       <img
         src="https://res.cloudinary.com/dyciw970t/image/upload/f_auto,q_auto,w_1200,c_limit/v1761961275/misqabbi/products/CSI_9996_poumla_df0276.jpg"
         alt="New arrival collection"
-        className="absolute inset-0 w-full h-full object-cover object-top"
+        className="absolute inset-0 w-full h-full object-cover object-top transition-transform duration-700 ease-out group-hover:scale-110"
         loading="lazy"
         decoding="async"
         width={1200}

--- a/src/components/landingpage/PreviewBanner.jsx
+++ b/src/components/landingpage/PreviewBanner.jsx
@@ -5,7 +5,7 @@ import { StaggerGroup, StaggerItem } from '../ui/motion/MotionWrappers';
 
 const PreviewBanner = () => {
   return (
-    <div className="group relative w-full h-[120px] md:h-[450px] overflow-hidden">
+    <div className="group relative w-full h-[200px] md:h-[500px] overflow-hidden">
       <img
         src="https://res.cloudinary.com/dyciw970t/image/upload/f_auto,q_auto,w_1200,c_limit/v1761961275/misqabbi/products/CSI_9996_poumla_df0276.jpg"
         alt="New arrival collection"
@@ -13,14 +13,17 @@ const PreviewBanner = () => {
         loading="lazy"
         decoding="async"
         width={1200}
-        height={450}
+        height={500}
       />
       <div className="absolute inset-0 bg-black/42" />
       <div className="relative z-10 h-full flex items-center justify-center">
-        <StaggerGroup className="text-center text-white md:space-y-4" staggerChildren={0.12}>
+        <StaggerGroup
+          className="flex w-full flex-col items-center justify-center space-y-3 px-4 text-center text-white md:space-y-4"
+          staggerChildren={0.12}
+        >
           <StaggerItem
             as="h1"
-            className="text-[40px] md:text-[128px] font-lato leading-[71px] w-[350px] md:w-[854px]"
+            className="mx-auto max-w-[min(92vw,854px)] text-balance font-lato text-[clamp(2.5rem,12vw,8rem)] leading-[0.9] tracking-tight"
           >
             NEW ARRIVAL
           </StaggerItem>
@@ -29,7 +32,7 @@ const PreviewBanner = () => {
               as={Link}
               to="/shop"
               variant="primarySlideWhite"
-              className="md:mt-12 px-5 py-3 font-lato"
+              className="mt-1 px-4 py-2 text-xs font-lato sm:px-5 sm:py-2.5 sm:text-sm md:mt-8 md:px-5 md:py-3 md:text-base lg:mt-12"
             >
               SHOP COLLECTION
             </Button>

--- a/src/components/landingpage/PreviewPromo.jsx
+++ b/src/components/landingpage/PreviewPromo.jsx
@@ -5,11 +5,11 @@ import { StaggerGroup, StaggerItem } from '../ui/motion/MotionWrappers';
 
 const PreviewPromo = () => {
   return (
-    <div className="relative w-full h-[120px] md:h-[450px] overflow-hidden">
+    <div className="group relative w-full h-[120px] md:h-[450px] overflow-hidden">
       <img
         src="https://res.cloudinary.com/dyciw970t/image/upload/f_auto,q_auto,w_1200,c_limit/v1761961275/misqabbi/products/CSI_9996_poumla_df0276.jpg"
         alt="Promotional banner"
-        className="absolute inset-0 w-full h-full object-cover object-bottom"
+        className="absolute inset-0 w-full h-full object-cover object-bottom transition-transform duration-700 ease-out group-hover:scale-110"
         loading="lazy"
         decoding="async"
         width={1200}

--- a/src/components/landingpage/PreviewPromo.jsx
+++ b/src/components/landingpage/PreviewPromo.jsx
@@ -1,3 +1,8 @@
+import { Link } from 'react-router';
+
+import Button from '../ui/Button';
+import { StaggerGroup, StaggerItem } from '../ui/motion/MotionWrappers';
+
 const PreviewPromo = () => {
   return (
     <div className="relative w-full h-[120px] md:h-[450px] overflow-hidden">
@@ -11,8 +16,25 @@ const PreviewPromo = () => {
         height={450}
       />
       <div className="absolute inset-0 bg-black/42" />
-      <div className="relative z-10 bg-opacity-40 flex items-center justify-center top-5 md:top-10 inset-x-0">
-        <h2 className=" text-[25px] md:text-[96px] w-[220px] font-lato text-white md:w-[743px] md:h-[154px]"></h2>
+      <div className="relative z-10 h-full flex items-center justify-center">
+        <StaggerGroup className="text-center text-white md:space-y-4" staggerChildren={0.12}>
+          <StaggerItem
+            as="h2"
+            className="text-[40px] md:text-[128px] font-lato leading-[71px] w-[350px] md:w-[854px]"
+          >
+            MADE FOR YOU
+          </StaggerItem>
+          <StaggerItem>
+            <Button
+              as={Link}
+              to="/bespoke"
+              variant="primarySlideWhite"
+              className="md:mt-12 px-5 py-3 font-lato"
+            >
+              START YOUR REQUEST
+            </Button>
+          </StaggerItem>
+        </StaggerGroup>
       </div>
     </div>
   );

--- a/src/components/landingpage/PreviewPromo.jsx
+++ b/src/components/landingpage/PreviewPromo.jsx
@@ -5,7 +5,7 @@ import { StaggerGroup, StaggerItem } from '../ui/motion/MotionWrappers';
 
 const PreviewPromo = () => {
   return (
-    <div className="group relative w-full h-[120px] md:h-[450px] overflow-hidden">
+    <div className="group relative w-full h-[200px] md:h-[500px] overflow-hidden">
       <img
         src="https://res.cloudinary.com/dyciw970t/image/upload/f_auto,q_auto,w_1200,c_limit/v1761961275/misqabbi/products/CSI_9996_poumla_df0276.jpg"
         alt="Promotional banner"
@@ -13,14 +13,17 @@ const PreviewPromo = () => {
         loading="lazy"
         decoding="async"
         width={1200}
-        height={450}
+        height={500}
       />
       <div className="absolute inset-0 bg-black/42" />
       <div className="relative z-10 h-full flex items-center justify-center">
-        <StaggerGroup className="text-center text-white md:space-y-4" staggerChildren={0.12}>
+        <StaggerGroup
+          className="flex w-full flex-col items-center justify-center space-y-3 px-4 text-center text-white md:space-y-4"
+          staggerChildren={0.12}
+        >
           <StaggerItem
             as="h2"
-            className="text-[40px] md:text-[128px] font-lato leading-[71px] w-[350px] md:w-[854px]"
+            className="mx-auto max-w-[min(92vw,854px)] text-balance font-lato text-[clamp(2.5rem,12vw,8rem)] leading-[0.9] tracking-tight"
           >
             MADE FOR YOU
           </StaggerItem>
@@ -29,7 +32,7 @@ const PreviewPromo = () => {
               as={Link}
               to="/bespoke"
               variant="primarySlideWhite"
-              className="md:mt-12 px-5 py-3 font-lato"
+              className="mt-1 px-4 py-2 text-xs font-lato sm:px-5 sm:py-2.5 sm:text-sm md:mt-8 md:px-5 md:py-3 md:text-base lg:mt-12"
             >
               SHOP BESPOKE
             </Button>

--- a/src/components/landingpage/PreviewPromo.jsx
+++ b/src/components/landingpage/PreviewPromo.jsx
@@ -31,7 +31,7 @@ const PreviewPromo = () => {
               variant="primarySlideWhite"
               className="md:mt-12 px-5 py-3 font-lato"
             >
-              START YOUR REQUEST
+              SHOP BESPOKE
             </Button>
           </StaggerItem>
         </StaggerGroup>

--- a/src/components/landingpage/PreviewSplit.jsx
+++ b/src/components/landingpage/PreviewSplit.jsx
@@ -8,11 +8,11 @@ const PreviewSplit = () => {
     <div className="w-full">
       <div className="grid grid-cols-1 md:grid-cols-2 ">
         {/* Denim Section */}
-        <div className="relative w-full h-[200px] md:h-[500px] overflow-hidden">
+        <div className="group relative w-full h-[200px] md:h-[500px] overflow-hidden">
           <img
             src="https://res.cloudinary.com/dyciw970t/image/upload/f_auto,q_auto,w_800,c_limit/v1761957976/misqabbi/products/CSI_0103_z9fxdo.jpg"
             alt="Dresses collection"
-            className="absolute inset-0 w-full h-full object-cover object-center"
+            className="absolute inset-0 w-full h-full object-cover object-center transition-transform duration-700 ease-out group-hover:scale-110"
             loading="lazy"
             decoding="async"
             width={800}
@@ -39,11 +39,11 @@ const PreviewSplit = () => {
         </div>
 
         {/* Ankara Section */}
-        <div className="relative w-full h-[200px] md:h-[500px] overflow-hidden">
+        <div className="group relative w-full h-[200px] md:h-[500px] overflow-hidden">
           <img
             src="https://res.cloudinary.com/dyciw970t/image/upload/f_auto,q_auto,w_800,c_limit/v1761963749/misqabbi/landing-page/CSI_9913_lvhkas_62433c.jpg"
             alt="Skirts collection"
-            className="absolute inset-0 w-full h-full object-cover object-center"
+            className="absolute inset-0 w-full h-full object-cover object-center transition-transform duration-700 ease-out group-hover:scale-110"
             loading="lazy"
             decoding="async"
             width={800}

--- a/src/components/layout/navigation/MobileMenu.jsx
+++ b/src/components/layout/navigation/MobileMenu.jsx
@@ -184,6 +184,14 @@ const MobileMenu = ({ isOpen, onClose }) => {
                     <div className="text-sm text-gray-500">Discover pieces that feel like you</div>
                   </Link>
                   <Link
+                    to="/bespoke"
+                    onClick={onClose}
+                    className="block py-3 px-3 text-msq-purple-rich hover:bg-gray-100 rounded-lg transition-colors duration-200"
+                  >
+                    <div className="font-medium">Bespoke</div>
+                    <div className="text-sm text-gray-500">Custom pieces crafted for you</div>
+                  </Link>
+                  <Link
                     to="/about-us"
                     onClick={onClose}
                     className="block py-3 px-3 text-msq-purple-rich hover:bg-gray-100 rounded-lg transition-colors duration-200"

--- a/src/components/layout/navigation/NavLinks.jsx
+++ b/src/components/layout/navigation/NavLinks.jsx
@@ -6,6 +6,7 @@ const NavLinks = ({ className = '', tone = 'solid' }) => {
 
   const links = [
     { to: '/shop', label: 'Shop' },
+    { to: '/bespoke', label: 'Bespoke' },
     { to: '/about-us', label: 'About' },
     { to: '/faqs', label: 'FAQs' },
     { to: '/contact-us', label: 'Contact' },

--- a/src/pages/Bespoke.jsx
+++ b/src/pages/Bespoke.jsx
@@ -1,0 +1,19 @@
+import SEO from '../components/SEO';
+import BespokeIntro from '../components/bespoke/BespokeIntro';
+import BespokeRequestForm from '../components/bespoke/BespokeRequestForm';
+
+const Bespoke = () => {
+  return (
+    <main className="w-full font-lato">
+      <SEO
+        title="Bespoke"
+        description="Request a bespoke piece or re-creation. Share your measurements, style, and reference photos."
+        canonicalPath="/bespoke"
+      />
+      <BespokeIntro />
+      <BespokeRequestForm />
+    </main>
+  );
+};
+
+export default Bespoke;


### PR DESCRIPTION
Introduces a dedicated bespoke request experience where users can submit custom garment requests with measurements, style notes, descriptions, and reference photos. The branch also adds navigation and landing-page entry points so shoppers can discover the bespoke flow.

Key changes:
- Add `/bespoke` route with SEO metadata, intro content, and the bespoke request form.
- Add multipart bespoke API submission via `submitBespokeRequest`, including credentials, reference photo uploads, measurement handling, and server error messaging.
- Support guest and logged-in bespoke submissions, with guest name/email/phone fields and authenticated user identity reuse.
- Add garment type selection, category-specific measurements, free-form “Other” garment measurements, style notes, description validation, and photo limits.
- Add Bespoke links to desktop and mobile navigation.
- Add a landing-page “Made for You” bespoke CTA and hover-scale polish across preview imagery.
- Update `PhoneNumberField` to show the Ghana country code as a display-only prefix.
- Document the expected backend bespoke API contract in `docs/BESPOKE_BACKEND_GUIDE.md`.