### PR TITLE
Add admin events CRUD pages and routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,10 @@ const AdminDiscounts = lazy(() => import('./pages/admin/AdminDiscounts'));
 const AdminDiscountDetail = lazy(() => import('./pages/admin/AdminDiscountDetail'));
 const AdminDiscountNew = lazy(() => import('./pages/admin/AdminDiscountNew'));
 const AdminDiscountEdit = lazy(() => import('./pages/admin/AdminDiscountEdit'));
+const AdminEvents = lazy(() => import('./pages/admin/AdminEvents'));
+const AdminEventNew = lazy(() => import('./pages/admin/AdminEventNew'));
+const AdminEventDetail = lazy(() => import('./pages/admin/AdminEventDetail'));
+const AdminEventEdit = lazy(() => import('./pages/admin/AdminEventEdit'));
 
 const App = () => {
   return (
@@ -337,6 +341,38 @@ const App = () => {
             element={
               <Suspense fallback={<PageLoader />}>
                 <AdminDiscountEdit />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEvents />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/new"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventNew />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/edit"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventEdit />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventDetail />
               </Suspense>
             }
           />

--- a/src/components/admin/EventForm.jsx
+++ b/src/components/admin/EventForm.jsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+import FormField from './FormField';
+import { EVENT_TYPE, EVENT_TYPES, EVENT_TYPE_LABELS } from '../../constants/events';
+
+const TYPE_OPTIONS = EVENT_TYPES.map(value => ({
+  value,
+  label: EVENT_TYPE_LABELS[value],
+}));
+
+const emptyForm = () => ({
+  name: '',
+  description: '',
+  eventDate: '',
+  type: EVENT_TYPE.FREE,
+  maxAttendees: '',
+  venueName: '',
+  venueAddress: '',
+  venueUrl: '',
+  bannerFile: null,
+  removeBanner: false,
+});
+
+const EventForm = ({ initialData = null, onSubmit, isLoading, error: submitError }) => {
+  const [formData, setFormData] = useState(() => {
+    if (!initialData) return emptyForm();
+    return {
+      name: initialData.name ?? '',
+      description: initialData.description ?? '',
+      eventDate: initialData.eventDate
+        ? new Date(initialData.eventDate).toISOString().slice(0, 16)
+        : '',
+      type: initialData.type ?? EVENT_TYPE.FREE,
+      maxAttendees: initialData.maxAttendees ?? '',
+      venueName: initialData.venue?.name ?? '',
+      venueAddress: initialData.venue?.address ?? '',
+      venueUrl: initialData.venue?.url ?? '',
+      bannerFile: null,
+      removeBanner: false,
+    };
+  });
+
+  const update = (key, value) => setFormData(prev => ({ ...prev, [key]: value }));
+
+  const buildPayload = () => {
+    const payload = {
+      name: formData.name.trim(),
+      description: formData.description,
+      eventDate: new Date(formData.eventDate).toISOString(),
+      type: formData.type,
+      maxAttendees: Number(formData.maxAttendees),
+      venue: {
+        name: formData.venueName.trim(),
+        address: formData.venueAddress.trim(),
+        url: formData.venueUrl.trim(),
+      },
+    };
+    if (formData.removeBanner) payload.banner = null;
+    return payload;
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onSubmit({
+      data: buildPayload(),
+      bannerFile: formData.bannerFile?.[0] || null,
+    });
+  };
+
+  const existingBanner = initialData?.banner?.url;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <FormField
+        label="Event Name"
+        value={formData.name}
+        onChange={value => update('name', value)}
+        placeholder="Summer showcase"
+        required
+        sanitizeType="name"
+      />
+
+      <FormField
+        label="Description"
+        type="textarea"
+        value={formData.description}
+        onChange={value => update('description', value)}
+        placeholder="Describe the event"
+        required
+        sanitizeType="description"
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <FormField
+          label="Event Date & Time"
+          type="datetime-local"
+          value={formData.eventDate}
+          onChange={value => update('eventDate', value)}
+          required
+        />
+
+        <FormField
+          label="Event Type"
+          type="select"
+          value={formData.type}
+          onChange={value => update('type', value)}
+          options={TYPE_OPTIONS}
+          required
+        />
+      </div>
+
+      <FormField
+        label="Max Attendees"
+        type="number"
+        value={formData.maxAttendees}
+        onChange={value => update('maxAttendees', value)}
+        placeholder="100"
+        required
+      />
+
+      <div className="border-t border-gray-200 pt-4">
+        <h3 className="text-sm font-medium text-gray-900 mb-3">Venue (optional)</h3>
+        <FormField
+          label="Venue Name"
+          value={formData.venueName}
+          onChange={value => update('venueName', value)}
+          placeholder="Misqabbi Studio"
+        />
+        <FormField
+          label="Venue Address"
+          value={formData.venueAddress}
+          onChange={value => update('venueAddress', value)}
+          placeholder="123 Fashion Street, Accra"
+        />
+        <FormField
+          label="Venue URL"
+          type="url"
+          value={formData.venueUrl}
+          onChange={value => update('venueUrl', value)}
+          placeholder="https://maps.google.com/..."
+        />
+      </div>
+
+      <div className="border-t border-gray-200 pt-4">
+        <h3 className="text-sm font-medium text-gray-900 mb-3">Banner (optional)</h3>
+        {existingBanner && !formData.removeBanner && (
+          <div className="mb-3">
+            <img
+              src={existingBanner}
+              alt="Current event banner"
+              className="h-32 w-full max-w-md object-cover rounded-lg border border-gray-200"
+            />
+            <button
+              type="button"
+              className="mt-2 text-sm text-red-600 hover:text-red-800"
+              onClick={() => update('removeBanner', true)}
+            >
+              Remove banner
+            </button>
+          </div>
+        )}
+        {formData.removeBanner && (
+          <p className="mb-2 text-sm text-amber-700">Banner will be removed on save.</p>
+        )}
+        <FormField
+          label="Upload Banner"
+          type="file"
+          value={formData.bannerFile}
+          onChange={files => {
+            update('bannerFile', files);
+            if (files?.length) update('removeBanner', false);
+          }}
+        />
+      </div>
+
+      {submitError && (
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{submitError}</div>
+      )}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="px-4 py-2 bg-msq-purple-rich text-white rounded-md hover:bg-msq-purple-deep disabled:opacity-50"
+      >
+        {isLoading ? 'Saving…' : initialData ? 'Update event' : 'Create event'}
+      </button>
+    </form>
+  );
+};
+
+export default EventForm;

--- a/src/components/admin/Sidebar.jsx
+++ b/src/components/admin/Sidebar.jsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router';
-import { LayoutDashboard, Package, ShoppingCart, Users, Tag, X } from 'lucide-react';
+import { LayoutDashboard, Package, ShoppingCart, Users, Tag, Calendar, X } from 'lucide-react';
 
 const Sidebar = ({ isOpen, onClose }) => {
   const location = useLocation();
@@ -8,6 +8,7 @@ const Sidebar = ({ isOpen, onClose }) => {
     { name: 'Products', href: '/admin/products', icon: Package },
     { name: 'Orders', href: '/admin/orders', icon: ShoppingCart },
     { name: 'Discounts', href: '/admin/discounts', icon: Tag },
+    { name: 'Events', href: '/admin/events', icon: Calendar },
     { name: 'Users', href: '/admin/users', icon: Users },
   ];
 

--- a/src/pages/admin/AdminEventDetail.jsx
+++ b/src/pages/admin/AdminEventDetail.jsx
@@ -1,0 +1,270 @@
+import { useState } from 'react';
+import { useParams, useNavigate, NavLink } from 'react-router';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import { useAdminEvent } from '../../hooks/queries/useAdmin';
+import { useUpdateAdminEventStatus } from '../../hooks/mutations/useEventMutations';
+import {
+  EVENT_STATUS,
+  EVENT_TYPE,
+  EVENT_STATUS_LABELS,
+  EVENT_TYPE_LABELS,
+} from '../../constants/events';
+import {
+  formatEventDate,
+  formatEventVenue,
+  getEventStatusColor,
+  getEventTypeColor,
+} from '../../utils/events';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const DETAIL_TABS = [
+  { key: 'overview', label: 'Overview', path: '' },
+  { key: 'tickets', label: 'Tickets', path: 'tickets', paidOnly: true },
+  { key: 'registration-form', label: 'Registration Form', path: 'registration-form' },
+  { key: 'volunteer-form', label: 'Volunteer Form', path: 'volunteer-form' },
+  { key: 'attendees', label: 'Attendees', path: 'attendees' },
+  { key: 'volunteers', label: 'Volunteers', path: 'volunteers' },
+];
+
+const AdminEventDetail = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const updateStatus = useUpdateAdminEventStatus();
+  const [statusError, setStatusError] = useState(null);
+
+  const { data: eventData, isLoading, isError, error } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load event'
+    : null;
+
+  const ticketTypes = event?.ticketTypes || [];
+  const hasActiveTickets = ticketTypes.some(t => t.isActive);
+  const showPaidTicketWarning =
+    event?.type === EVENT_TYPE.PAID && event?.status === EVENT_STATUS.DRAFT && !hasActiveTickets;
+
+  const canPublish = event?.status === EVENT_STATUS.DRAFT;
+  const canCancel =
+    event?.status === EVENT_STATUS.DRAFT || event?.status === EVENT_STATUS.PUBLISHED;
+
+  const handleStatusChange = async newStatus => {
+    const labels = {
+      [EVENT_STATUS.PUBLISHED]: 'publish',
+      [EVENT_STATUS.CANCELLED]: 'cancel',
+    };
+    const action = labels[newStatus] || 'update';
+    if (!window.confirm(`Are you sure you want to ${action} this event?`)) return;
+
+    setStatusError(null);
+    try {
+      await updateStatus.mutateAsync({ id, status: newStatus });
+      showSuccessToast(`Event ${action === 'publish' ? 'published' : `${action}led`}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update status';
+      setStatusError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to events
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{errMsg}</div>
+      </div>
+    );
+
+  if (!event)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to events
+        </button>
+        <p className="text-gray-500">Event not found.</p>
+      </div>
+    );
+
+  const venueLabel = formatEventVenue(event.venue);
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <button
+            className="mb-2 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+            onClick={() => navigate('/admin/events')}
+          >
+            Back to events
+          </button>
+          <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
+            {event.name}
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">/{event.slug}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+            onClick={() => navigate(`/admin/events/${id}/edit`)}
+          >
+            Edit
+          </button>
+          {canPublish && (
+            <button
+              type="button"
+              disabled={updateStatus.isPending}
+              className="px-3 py-2 text-sm bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50"
+              onClick={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
+            >
+              Publish
+            </button>
+          )}
+          {canCancel && (
+            <button
+              type="button"
+              disabled={updateStatus.isPending}
+              className="px-3 py-2 text-sm bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
+              onClick={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
+            >
+              Cancel event
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showPaidTicketWarning && (
+        <div className="mb-4 p-3 rounded-md bg-amber-50 text-amber-800 text-sm border border-amber-200">
+          This paid event has no active ticket types. Add at least one active ticket before
+          publishing.
+        </div>
+      )}
+
+      {statusError && (
+        <div className="mb-4 p-3 rounded-md bg-red-50 text-red-600 text-sm">{statusError}</div>
+      )}
+
+      <nav className="mb-6 flex flex-wrap gap-2 border-b border-gray-200 pb-3">
+        {DETAIL_TABS.filter(tab => !tab.paidOnly || event.type === EVENT_TYPE.PAID).map(tab => {
+          const to = tab.path ? `/admin/events/${id}/${tab.path}` : `/admin/events/${id}`;
+          const isStub = tab.key !== 'overview';
+          return (
+            <NavLink
+              key={tab.key}
+              to={to}
+              end={!tab.path}
+              className={({ isActive }) =>
+                `px-3 py-1.5 text-sm rounded-md transition-colors ${
+                  isActive ? 'bg-msq-purple-rich text-white' : 'text-gray-600 hover:bg-gray-100'
+                } ${isStub ? 'opacity-60 pointer-events-none' : ''}`
+              }
+            >
+              {tab.label}
+            </NavLink>
+          );
+        })}
+      </nav>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {event.banner?.url && (
+          <div className="lg:col-span-3">
+            <img
+              src={event.banner.url}
+              alt={event.name}
+              className="w-full max-h-64 object-cover rounded-lg border border-gray-200"
+            />
+          </div>
+        )}
+
+        <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Details</h2>
+          <div
+            className="prose prose-sm max-w-none text-gray-700 mb-6"
+            dangerouslySetInnerHTML={{ __html: event.description }}
+          />
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+            <div>
+              <dt className="text-gray-500">Date</dt>
+              <dd className="font-medium text-gray-900">{formatEventDate(event.eventDate)}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Capacity</dt>
+              <dd className="font-medium text-gray-900">{event.maxAttendees}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Type</dt>
+              <dd>
+                <span
+                  className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventTypeColor(event.type)}`}
+                >
+                  {EVENT_TYPE_LABELS[event.type]}
+                </span>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Status</dt>
+              <dd>
+                <span
+                  className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventStatusColor(event.status)}`}
+                >
+                  {EVENT_STATUS_LABELS[event.status]}
+                </span>
+              </dd>
+            </div>
+            {venueLabel && (
+              <div className="sm:col-span-2">
+                <dt className="text-gray-500">Venue</dt>
+                <dd className="font-medium text-gray-900">
+                  {venueLabel}
+                  {event.venue?.url && (
+                    <>
+                      {' · '}
+                      <a
+                        href={event.venue.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-msq-purple-rich hover:underline"
+                      >
+                        Map link
+                      </a>
+                    </>
+                  )}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Manage</h2>
+          <ul className="space-y-2 text-sm text-gray-600">
+            <li>Tickets, forms, attendees, and volunteers will be available in upcoming tabs.</li>
+            {event.type === EVENT_TYPE.PAID && (
+              <li>
+                Ticket types: {ticketTypes.length} configured
+                {hasActiveTickets ? ' (active tickets available)' : ' (none active yet)'}
+              </li>
+            )}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminEventDetail;

--- a/src/pages/admin/AdminEventEdit.jsx
+++ b/src/pages/admin/AdminEventEdit.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import EventForm from '../../components/admin/EventForm';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import { useAdminEvent } from '../../hooks/queries/useAdmin';
+import { useUpdateAdminEvent } from '../../hooks/mutations/useEventMutations';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const AdminEventEdit = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const updateEvent = useUpdateAdminEvent();
+  const [error, setError] = useState(null);
+
+  const { data: eventData, isLoading, isError, error: queryError } = useAdminEvent(id);
+  const event = eventData?.data || null;
+  const errMsg = isError
+    ? queryError?.response?.data?.error || queryError?.message || 'Failed to load event'
+    : null;
+
+  const handleSubmit = async ({ data, bannerFile }) => {
+    setError(null);
+    try {
+      await updateEvent.mutateAsync({ id, data, bannerFile });
+      showSuccessToast('Event updated');
+      navigate(`/admin/events/${id}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update event';
+      setError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to list
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{errMsg}</div>
+      </div>
+    );
+
+  if (!event)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to list
+        </button>
+        <p className="text-gray-500">Event not found.</p>
+      </div>
+    );
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
+          Edit event: {event.name}
+        </h1>
+        <button
+          type="button"
+          className="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate(`/admin/events/${id}`)}
+        >
+          Back to detail
+        </button>
+      </div>
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <EventForm
+          initialData={event}
+          onSubmit={handleSubmit}
+          isLoading={updateEvent.isPending}
+          error={error}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AdminEventEdit;

--- a/src/pages/admin/AdminEventNew.jsx
+++ b/src/pages/admin/AdminEventNew.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import EventForm from '../../components/admin/EventForm';
+import { useCreateAdminEvent } from '../../hooks/mutations/useEventMutations';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const AdminEventNew = () => {
+  const navigate = useNavigate();
+  const createEvent = useCreateAdminEvent();
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async ({ data, bannerFile }) => {
+    setError(null);
+    try {
+      const res = await createEvent.mutateAsync({ data, bannerFile });
+      showSuccessToast('Event created');
+      const id = res?.data?._id;
+      if (id) navigate(`/admin/events/${id}`);
+      else navigate('/admin/events');
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to create event';
+      setError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
+          Create event
+        </h1>
+        <button
+          type="button"
+          className="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to list
+        </button>
+      </div>
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <EventForm onSubmit={handleSubmit} isLoading={createEvent.isPending} error={error} />
+      </div>
+    </div>
+  );
+};
+
+export default AdminEventNew;

--- a/src/pages/admin/AdminEvents.jsx
+++ b/src/pages/admin/AdminEvents.jsx
@@ -1,0 +1,170 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import DataTable from '../../components/admin/DataTable';
+import PageHeader from '../../components/admin/PageHeader';
+import { ViewButton, EditButton } from '../../components/admin/ActionButton';
+import PaginationLocal from '../../components/orders/PaginationLocal';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import { useAdminEvents } from '../../hooks/queries/useAdmin';
+import {
+  EVENT_STATUSES,
+  EVENT_TYPES,
+  EVENT_STATUS_LABELS,
+  EVENT_TYPE_LABELS,
+} from '../../constants/events';
+import { formatEventDateShort } from '../../utils/events';
+import { getEventStatusColor, getEventTypeColor } from '../../utils/events/statusBadges';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  ...EVENT_STATUSES.map(value => ({ value, label: EVENT_STATUS_LABELS[value] })),
+];
+
+const TYPE_OPTIONS = [
+  { value: '', label: 'All types' },
+  ...EVENT_TYPES.map(value => ({ value, label: EVENT_TYPE_LABELS[value] })),
+];
+
+const AdminEvents = () => {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('');
+  const [type, setType] = useState('');
+
+  useEffect(() => {
+    setPage(1);
+  }, [q, status, type]);
+
+  const params = { page, limit };
+  if (q.trim()) params.q = q.trim();
+  if (status) params.status = status;
+  if (type) params.type = type;
+
+  const { data, isLoading, isError, error } = useAdminEvents(params);
+  const rawList = data?.data || [];
+  const list = rawList.map(item => ({ ...item, id: item._id }));
+  const pagination = data?.pagination || {};
+  const totalPages = pagination.totalPages || 1;
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load events'
+    : null;
+
+  const columns = [
+    {
+      key: 'name',
+      label: 'Name',
+      render: v => <span className="font-medium text-gray-900">{v || '—'}</span>,
+    },
+    {
+      key: 'eventDate',
+      label: 'Date',
+      render: v => formatEventDateShort(v),
+    },
+    {
+      key: 'type',
+      label: 'Type',
+      render: v => (
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full capitalize ${getEventTypeColor(v)}`}
+        >
+          {EVENT_TYPE_LABELS[v] || v || '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: v => (
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full capitalize ${getEventStatusColor(v)}`}
+        >
+          {EVENT_STATUS_LABELS[v] || v || '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'maxAttendees',
+      label: 'Capacity',
+      render: v => (v != null ? v : '—'),
+    },
+  ];
+
+  const actions = [
+    { component: ViewButton, onClick: e => navigate(`/admin/events/${e._id}`), title: 'View' },
+    {
+      component: EditButton,
+      onClick: e => navigate(`/admin/events/${e._id}/edit`),
+      title: 'Edit',
+    },
+  ];
+
+  return (
+    <div>
+      <PageHeader
+        title="Events"
+        actionLabel="Create event"
+        onAction={() => navigate('/admin/events/new')}
+      />
+
+      <div className="mb-4 p-4 bg-white rounded-lg border border-gray-200">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <input
+            type="search"
+            placeholder="Search events"
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich focus:border-msq-purple-rich"
+          />
+          <select
+            value={status}
+            onChange={e => setStatus(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich"
+          >
+            {STATUS_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={type}
+            onChange={e => setType(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich"
+          >
+            {TYPE_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {errMsg && (
+        <div className="mb-4 p-3 rounded-md bg-red-50 text-red-600 text-sm font-lato">{errMsg}</div>
+      )}
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <LoadingSpinner size={48} />
+        </div>
+      ) : (
+        <>
+          <DataTable columns={columns} data={list} actions={actions} />
+          {totalPages > 1 && (
+            <PaginationLocal
+              page={page}
+              totalPages={totalPages}
+              onPrev={() => setPage(p => Math.max(1, p - 1))}
+              onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default AdminEvents;


### PR DESCRIPTION
Add admin-facing event management so staff can create, list, edit, and publish events. Mirrors existing AdminDiscounts patterns and wires routes under /admin/events.

- Add EventForm with RichTextEditor, multipart banner upload, and venue fields
- Add AdminEvents list page with DataTable, filters, and pagination
- Add AdminEventNew and AdminEventEdit pages
- Add AdminEventDetail with draft → published/cancelled status actions and stub tabs
- Register /admin/events routes and sidebar entry
