### PR TITLE
Add admin event ticket type management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,6 +52,7 @@ const AdminEvents = lazy(() => import('./pages/admin/AdminEvents'));
 const AdminEventNew = lazy(() => import('./pages/admin/AdminEventNew'));
 const AdminEventDetail = lazy(() => import('./pages/admin/AdminEventDetail'));
 const AdminEventEdit = lazy(() => import('./pages/admin/AdminEventEdit'));
+const AdminEventTickets = lazy(() => import('./pages/admin/AdminEventTickets'));
 
 const App = () => {
   return (
@@ -365,6 +366,14 @@ const App = () => {
             element={
               <Suspense fallback={<PageLoader />}>
                 <AdminEventEdit />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/tickets"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventTickets />
               </Suspense>
             }
           />

--- a/src/components/admin/AdminEventDetailLayout.jsx
+++ b/src/components/admin/AdminEventDetailLayout.jsx
@@ -1,0 +1,125 @@
+import { NavLink } from 'react-router';
+import { EVENT_TYPE_LABELS, EVENT_STATUS_LABELS, EVENT_TYPE } from '../../constants/events';
+import { getEventStatusColor, getEventTypeColor } from '../../utils/events';
+
+export const DETAIL_TABS = [
+  { key: 'overview', label: 'Overview', path: '' },
+  { key: 'tickets', label: 'Tickets', path: 'tickets', paidOnly: true },
+  { key: 'registration-form', label: 'Registration Form', path: 'registration-form', stub: true },
+  { key: 'volunteer-form', label: 'Volunteer Form', path: 'volunteer-form', stub: true },
+  { key: 'attendees', label: 'Attendees', path: 'attendees', stub: true },
+  { key: 'volunteers', label: 'Volunteers', path: 'volunteers', stub: true },
+];
+
+const AdminEventDetailLayout = ({
+  event,
+  eventId,
+  onBack,
+  onEdit,
+  canPublish,
+  canCancel,
+  onPublish,
+  onCancel,
+  isUpdatingStatus,
+  showPaidTicketWarning,
+  statusError,
+  children,
+}) => {
+  const visibleTabs = DETAIL_TABS.filter(tab => !tab.paidOnly || event.type === EVENT_TYPE.PAID);
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <button
+            className="mb-2 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+            onClick={onBack}
+          >
+            Back to events
+          </button>
+          <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
+            {event.name}
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">/{event.slug}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+            onClick={onEdit}
+          >
+            Edit
+          </button>
+          {canPublish && (
+            <button
+              type="button"
+              disabled={isUpdatingStatus}
+              className="px-3 py-2 text-sm bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50"
+              onClick={onPublish}
+            >
+              Publish
+            </button>
+          )}
+          {canCancel && (
+            <button
+              type="button"
+              disabled={isUpdatingStatus}
+              className="px-3 py-2 text-sm bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
+              onClick={onCancel}
+            >
+              Cancel event
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-4 flex flex-wrap gap-2 text-sm">
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventTypeColor(event.type)}`}
+        >
+          {EVENT_TYPE_LABELS[event.type]}
+        </span>
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventStatusColor(event.status)}`}
+        >
+          {EVENT_STATUS_LABELS[event.status]}
+        </span>
+      </div>
+
+      {showPaidTicketWarning && (
+        <div className="mb-4 p-3 rounded-md bg-amber-50 text-amber-800 text-sm border border-amber-200">
+          This paid event has no active ticket types. Add at least one active ticket before
+          publishing.
+        </div>
+      )}
+
+      {statusError && (
+        <div className="mb-4 p-3 rounded-md bg-red-50 text-red-600 text-sm">{statusError}</div>
+      )}
+
+      <nav className="mb-6 flex flex-wrap gap-2 border-b border-gray-200 pb-3">
+        {visibleTabs.map(tab => {
+          const to = tab.path ? `/admin/events/${eventId}/${tab.path}` : `/admin/events/${eventId}`;
+          return (
+            <NavLink
+              key={tab.key}
+              to={to}
+              end={!tab.path}
+              className={({ isActive }) =>
+                `px-3 py-1.5 text-sm rounded-md transition-colors ${
+                  isActive ? 'bg-msq-purple-rich text-white' : 'text-gray-600 hover:bg-gray-100'
+                } ${tab.stub ? 'opacity-60 pointer-events-none' : ''}`
+              }
+            >
+              {tab.label}
+            </NavLink>
+          );
+        })}
+      </nav>
+
+      {children}
+    </div>
+  );
+};
+
+export default AdminEventDetailLayout;

--- a/src/components/admin/EventTicketTypesPanel.jsx
+++ b/src/components/admin/EventTicketTypesPanel.jsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import TicketTypeForm from './TicketTypeForm';
+import { DeleteButton, EditButton } from './ActionButton';
+import {
+  useCreateAdminTicketType,
+  useUpdateAdminTicketType,
+  useDeleteAdminTicketType,
+} from '../../hooks/mutations/useEventMutations';
+import { formatCurrency } from '../../utils/admin/tableHelpers';
+import { formatEventDate, pesewasToGhs } from '../../utils/events';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const EventTicketTypesPanel = ({ eventId, ticketTypes = [] }) => {
+  const createTicket = useCreateAdminTicketType();
+  const updateTicket = useUpdateAdminTicketType();
+  const deleteTicket = useDeleteAdminTicketType();
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingTicket, setEditingTicket] = useState(null);
+  const [formError, setFormError] = useState(null);
+
+  const handleCreate = async body => {
+    setFormError(null);
+    try {
+      await createTicket.mutateAsync({ eventId, body });
+      showSuccessToast('Ticket type added');
+      setShowForm(false);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to add ticket type';
+      setFormError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  const handleUpdate = async body => {
+    setFormError(null);
+    try {
+      await updateTicket.mutateAsync({
+        eventId,
+        ticketTypeId: editingTicket._id,
+        body,
+      });
+      showSuccessToast('Ticket type updated');
+      setEditingTicket(null);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update ticket type';
+      setFormError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  const handleDelete = async ticket => {
+    if (ticket.soldCount > 0) {
+      showErrorToast('Cannot delete a ticket type that has sales');
+      return;
+    }
+    if (!window.confirm(`Delete ticket type "${ticket.name}"?`)) return;
+    try {
+      await deleteTicket.mutateAsync({ eventId, ticketTypeId: ticket._id });
+      showSuccessToast('Ticket type deleted');
+    } catch (err) {
+      showErrorToast(err?.response?.data?.error || err?.message || 'Failed to delete ticket type');
+    }
+  };
+
+  const isSaving = createTicket.isPending || updateTicket.isPending;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Ticket types</h2>
+        {!showForm && !editingTicket && (
+          <button
+            type="button"
+            className="px-3 py-2 text-sm bg-msq-purple-rich text-white rounded-md hover:bg-msq-purple-deep"
+            onClick={() => setShowForm(true)}
+          >
+            Add ticket type
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <TicketTypeForm
+          onSubmit={handleCreate}
+          onCancel={() => {
+            setShowForm(false);
+            setFormError(null);
+          }}
+          isLoading={isSaving}
+          error={formError}
+        />
+      )}
+
+      {editingTicket && (
+        <TicketTypeForm
+          initialData={editingTicket}
+          onSubmit={handleUpdate}
+          onCancel={() => {
+            setEditingTicket(null);
+            setFormError(null);
+          }}
+          isLoading={isSaving}
+          error={formError}
+        />
+      )}
+
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        {ticketTypes.length === 0 ? (
+          <p className="p-6 text-sm text-gray-500">No ticket types yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  {['Name', 'Price', 'Sold', 'Remaining', 'Expires', 'Active', 'Actions'].map(
+                    label => (
+                      <th
+                        key={label}
+                        className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase"
+                      >
+                        {label}
+                      </th>
+                    )
+                  )}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {ticketTypes.map(ticket => {
+                  const remaining = Math.max(
+                    0,
+                    (ticket.maxQuantity || 0) - (ticket.soldCount || 0)
+                  );
+                  return (
+                    <tr key={ticket._id}>
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900">{ticket.name}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">
+                        {formatCurrency(pesewasToGhs(ticket.pricePesewas))}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{ticket.soldCount || 0}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{remaining}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">
+                        {ticket.expiresAt ? formatEventDate(ticket.expiresAt) : '—'}
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {ticket.isActive ? (
+                          <span className="text-emerald-700">Yes</span>
+                        ) : (
+                          <span className="text-gray-500">No</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        <div className="flex gap-2">
+                          <EditButton
+                            onClick={() => {
+                              setShowForm(false);
+                              setEditingTicket(ticket);
+                            }}
+                            title="Edit"
+                          />
+                          {ticket.soldCount === 0 && (
+                            <DeleteButton onClick={() => handleDelete(ticket)} title="Delete" />
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EventTicketTypesPanel;

--- a/src/components/admin/TicketTypeForm.jsx
+++ b/src/components/admin/TicketTypeForm.jsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import FormField from './FormField';
+import { ghsToPesewas, pesewasToGhs } from '../../utils/events';
+
+const emptyForm = () => ({
+  name: '',
+  priceGhs: '',
+  maxQuantity: '',
+  expiresAt: '',
+  isActive: true,
+});
+
+const TicketTypeForm = ({ initialData = null, onSubmit, onCancel, isLoading, error }) => {
+  const [formData, setFormData] = useState(() => {
+    if (!initialData) return emptyForm();
+    return {
+      name: initialData.name ?? '',
+      priceGhs: pesewasToGhs(initialData.pricePesewas).toFixed(2),
+      maxQuantity: initialData.maxQuantity ?? '',
+      expiresAt: initialData.expiresAt
+        ? new Date(initialData.expiresAt).toISOString().slice(0, 16)
+        : '',
+      isActive: initialData.isActive !== false,
+    };
+  });
+
+  const update = (key, value) => setFormData(prev => ({ ...prev, [key]: value }));
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onSubmit({
+      name: formData.name.trim(),
+      pricePesewas: ghsToPesewas(formData.priceGhs),
+      maxQuantity: Number(formData.maxQuantity),
+      expiresAt: formData.expiresAt ? new Date(formData.expiresAt).toISOString() : undefined,
+      isActive: formData.isActive,
+    });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 border border-gray-200 rounded-lg p-4 bg-gray-50"
+    >
+      <h3 className="text-sm font-semibold text-gray-900">
+        {initialData ? 'Edit ticket type' : 'New ticket type'}
+      </h3>
+
+      <FormField
+        label="Name"
+        value={formData.name}
+        onChange={value => update('name', value)}
+        placeholder="General admission"
+        required
+      />
+
+      <FormField
+        label="Price (GHS)"
+        type="number"
+        value={formData.priceGhs}
+        onChange={value => update('priceGhs', value)}
+        placeholder="50.00"
+        required
+      />
+
+      <FormField
+        label="Max quantity"
+        type="number"
+        value={formData.maxQuantity}
+        onChange={value => update('maxQuantity', value)}
+        placeholder="100"
+        required
+      />
+
+      <FormField
+        label="Expires at"
+        type="datetime-local"
+        value={formData.expiresAt}
+        onChange={value => update('expiresAt', value)}
+      />
+
+      <label className="flex items-center gap-2 text-sm text-gray-700">
+        <input
+          type="checkbox"
+          checked={formData.isActive}
+          onChange={e => update('isActive', e.target.checked)}
+          className="h-4 w-4 rounded border-gray-300"
+        />
+        Active (available for purchase)
+      </label>
+
+      {error && <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{error}</div>}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="px-4 py-2 bg-msq-purple-rich text-white rounded-md hover:bg-msq-purple-deep disabled:opacity-50"
+        >
+          {isLoading ? 'Saving…' : initialData ? 'Update ticket' : 'Add ticket'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            className="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};
+
+export default TicketTypeForm;

--- a/src/pages/admin/AdminEventDetail.jsx
+++ b/src/pages/admin/AdminEventDetail.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { useParams, useNavigate, NavLink } from 'react-router';
+import { useParams, useNavigate } from 'react-router';
 import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import AdminEventDetailLayout from '../../components/admin/AdminEventDetailLayout';
 import { useAdminEvent } from '../../hooks/queries/useAdmin';
 import { useUpdateAdminEventStatus } from '../../hooks/mutations/useEventMutations';
 import {
@@ -16,15 +17,6 @@ import {
   getEventTypeColor,
 } from '../../utils/events';
 import { showSuccessToast, showErrorToast } from '../../utils/showToast';
-
-const DETAIL_TABS = [
-  { key: 'overview', label: 'Overview', path: '' },
-  { key: 'tickets', label: 'Tickets', path: 'tickets', paidOnly: true },
-  { key: 'registration-form', label: 'Registration Form', path: 'registration-form' },
-  { key: 'volunteer-form', label: 'Volunteer Form', path: 'volunteer-form' },
-  { key: 'attendees', label: 'Attendees', path: 'attendees' },
-  { key: 'volunteers', label: 'Volunteers', path: 'volunteers' },
-];
 
 const AdminEventDetail = () => {
   const { id } = useParams();
@@ -44,18 +36,10 @@ const AdminEventDetail = () => {
   const showPaidTicketWarning =
     event?.type === EVENT_TYPE.PAID && event?.status === EVENT_STATUS.DRAFT && !hasActiveTickets;
 
-  const canPublish = event?.status === EVENT_STATUS.DRAFT;
-  const canCancel =
-    event?.status === EVENT_STATUS.DRAFT || event?.status === EVENT_STATUS.PUBLISHED;
-
   const handleStatusChange = async newStatus => {
-    const labels = {
-      [EVENT_STATUS.PUBLISHED]: 'publish',
-      [EVENT_STATUS.CANCELLED]: 'cancel',
-    };
+    const labels = { [EVENT_STATUS.PUBLISHED]: 'publish', [EVENT_STATUS.CANCELLED]: 'cancel' };
     const action = labels[newStatus] || 'update';
     if (!window.confirm(`Are you sure you want to ${action} this event?`)) return;
-
     setStatusError(null);
     try {
       await updateStatus.mutateAsync({ id, status: newStatus });
@@ -74,7 +58,7 @@ const AdminEventDetail = () => {
       </div>
     );
 
-  if (errMsg)
+  if (errMsg || !event)
     return (
       <div>
         <button
@@ -83,103 +67,28 @@ const AdminEventDetail = () => {
         >
           Back to events
         </button>
-        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{errMsg}</div>
-      </div>
-    );
-
-  if (!event)
-    return (
-      <div>
-        <button
-          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
-          onClick={() => navigate('/admin/events')}
-        >
-          Back to events
-        </button>
-        <p className="text-gray-500">Event not found.</p>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Event not found.'}
+        </div>
       </div>
     );
 
   const venueLabel = formatEventVenue(event.venue);
 
   return (
-    <div>
-      <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <div>
-          <button
-            className="mb-2 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
-            onClick={() => navigate('/admin/events')}
-          >
-            Back to events
-          </button>
-          <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
-            {event.name}
-          </h1>
-          <p className="text-sm text-gray-500 mt-1">/{event.slug}</p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            className="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
-            onClick={() => navigate(`/admin/events/${id}/edit`)}
-          >
-            Edit
-          </button>
-          {canPublish && (
-            <button
-              type="button"
-              disabled={updateStatus.isPending}
-              className="px-3 py-2 text-sm bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50"
-              onClick={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
-            >
-              Publish
-            </button>
-          )}
-          {canCancel && (
-            <button
-              type="button"
-              disabled={updateStatus.isPending}
-              className="px-3 py-2 text-sm bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
-              onClick={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
-            >
-              Cancel event
-            </button>
-          )}
-        </div>
-      </div>
-
-      {showPaidTicketWarning && (
-        <div className="mb-4 p-3 rounded-md bg-amber-50 text-amber-800 text-sm border border-amber-200">
-          This paid event has no active ticket types. Add at least one active ticket before
-          publishing.
-        </div>
-      )}
-
-      {statusError && (
-        <div className="mb-4 p-3 rounded-md bg-red-50 text-red-600 text-sm">{statusError}</div>
-      )}
-
-      <nav className="mb-6 flex flex-wrap gap-2 border-b border-gray-200 pb-3">
-        {DETAIL_TABS.filter(tab => !tab.paidOnly || event.type === EVENT_TYPE.PAID).map(tab => {
-          const to = tab.path ? `/admin/events/${id}/${tab.path}` : `/admin/events/${id}`;
-          const isStub = tab.key !== 'overview';
-          return (
-            <NavLink
-              key={tab.key}
-              to={to}
-              end={!tab.path}
-              className={({ isActive }) =>
-                `px-3 py-1.5 text-sm rounded-md transition-colors ${
-                  isActive ? 'bg-msq-purple-rich text-white' : 'text-gray-600 hover:bg-gray-100'
-                } ${isStub ? 'opacity-60 pointer-events-none' : ''}`
-              }
-            >
-              {tab.label}
-            </NavLink>
-          );
-        })}
-      </nav>
-
+    <AdminEventDetailLayout
+      event={event}
+      eventId={id}
+      onBack={() => navigate('/admin/events')}
+      onEdit={() => navigate(`/admin/events/${id}/edit`)}
+      canPublish={event.status === EVENT_STATUS.DRAFT}
+      canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}
+      onPublish={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
+      onCancel={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
+      isUpdatingStatus={updateStatus.isPending}
+      showPaidTicketWarning={showPaidTicketWarning}
+      statusError={statusError}
+    >
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {event.banner?.url && (
           <div className="lg:col-span-3">
@@ -253,17 +162,17 @@ const AdminEventDetail = () => {
         <div className="bg-white rounded-lg border border-gray-200 p-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4">Manage</h2>
           <ul className="space-y-2 text-sm text-gray-600">
-            <li>Tickets, forms, attendees, and volunteers will be available in upcoming tabs.</li>
             {event.type === EVENT_TYPE.PAID && (
               <li>
                 Ticket types: {ticketTypes.length} configured
                 {hasActiveTickets ? ' (active tickets available)' : ' (none active yet)'}
               </li>
             )}
+            <li>Use the tabs above to manage tickets, forms, attendees, and volunteers.</li>
           </ul>
         </div>
       </div>
-    </div>
+    </AdminEventDetailLayout>
   );
 };
 

--- a/src/pages/admin/AdminEventTickets.jsx
+++ b/src/pages/admin/AdminEventTickets.jsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import AdminEventDetailLayout from '../../components/admin/AdminEventDetailLayout';
+import EventTicketTypesPanel from '../../components/admin/EventTicketTypesPanel';
+import { useAdminEvent } from '../../hooks/queries/useAdmin';
+import { useUpdateAdminEventStatus } from '../../hooks/mutations/useEventMutations';
+import { EVENT_STATUS, EVENT_TYPE } from '../../constants/events';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const AdminEventTickets = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const updateStatus = useUpdateAdminEventStatus();
+  const [statusError, setStatusError] = useState(null);
+
+  const { data: eventData, isLoading, isError, error } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load event'
+    : null;
+
+  const ticketTypes = event?.ticketTypes || [];
+  const hasActiveTickets = ticketTypes.some(t => t.isActive);
+  const showPaidTicketWarning =
+    event?.type === EVENT_TYPE.PAID && event?.status === EVENT_STATUS.DRAFT && !hasActiveTickets;
+
+  const handleStatusChange = async newStatus => {
+    const labels = { [EVENT_STATUS.PUBLISHED]: 'publish', [EVENT_STATUS.CANCELLED]: 'cancel' };
+    const action = labels[newStatus] || 'update';
+    if (!window.confirm(`Are you sure you want to ${action} this event?`)) return;
+    setStatusError(null);
+    try {
+      await updateStatus.mutateAsync({ id, status: newStatus });
+      showSuccessToast(`Event ${action === 'publish' ? 'published' : `${action}led`}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update status';
+      setStatusError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg || !event)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to events
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Event not found.'}
+        </div>
+      </div>
+    );
+
+  if (event.type !== EVENT_TYPE.PAID) {
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate(`/admin/events/${id}`)}
+        >
+          Back to event
+        </button>
+        <p className="text-gray-600">Ticket types are only available for paid events.</p>
+      </div>
+    );
+  }
+
+  return (
+    <AdminEventDetailLayout
+      event={event}
+      eventId={id}
+      onBack={() => navigate('/admin/events')}
+      onEdit={() => navigate(`/admin/events/${id}/edit`)}
+      canPublish={event.status === EVENT_STATUS.DRAFT}
+      canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}
+      onPublish={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
+      onCancel={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
+      isUpdatingStatus={updateStatus.isPending}
+      showPaidTicketWarning={showPaidTicketWarning}
+      statusError={statusError}
+    >
+      <EventTicketTypesPanel eventId={id} ticketTypes={ticketTypes} />
+    </AdminEventDetailLayout>
+  );
+};
+
+export default AdminEventTickets;


### PR DESCRIPTION
Add ticket type management for paid events on the admin event detail hub. Staff can create, edit, and delete ticket types (delete only when none sold).

- Add TicketTypeForm with GHS to pesewas conversion
- Add EventTicketTypesPanel with sold/remaining counts and active flag
- Extract AdminEventDetailLayout and wire /admin/events/:id/tickets route
