### PR TITLE
Add admin event registration and volunteer form builder

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,6 +53,8 @@ const AdminEventNew = lazy(() => import('./pages/admin/AdminEventNew'));
 const AdminEventDetail = lazy(() => import('./pages/admin/AdminEventDetail'));
 const AdminEventEdit = lazy(() => import('./pages/admin/AdminEventEdit'));
 const AdminEventTickets = lazy(() => import('./pages/admin/AdminEventTickets'));
+const AdminEventRegistrationForm = lazy(() => import('./pages/admin/AdminEventRegistrationForm'));
+const AdminEventVolunteerForm = lazy(() => import('./pages/admin/AdminEventVolunteerForm'));
 
 const App = () => {
   return (
@@ -374,6 +376,22 @@ const App = () => {
             element={
               <Suspense fallback={<PageLoader />}>
                 <AdminEventTickets />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/registration-form"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventRegistrationForm />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/volunteer-form"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventVolunteerForm />
               </Suspense>
             }
           />

--- a/src/components/admin/AdminEventDetailLayout.jsx
+++ b/src/components/admin/AdminEventDetailLayout.jsx
@@ -5,8 +5,8 @@ import { getEventStatusColor, getEventTypeColor } from '../../utils/events';
 export const DETAIL_TABS = [
   { key: 'overview', label: 'Overview', path: '' },
   { key: 'tickets', label: 'Tickets', path: 'tickets', paidOnly: true },
-  { key: 'registration-form', label: 'Registration Form', path: 'registration-form', stub: true },
-  { key: 'volunteer-form', label: 'Volunteer Form', path: 'volunteer-form', stub: true },
+  { key: 'registration-form', label: 'Registration Form', path: 'registration-form' },
+  { key: 'volunteer-form', label: 'Volunteer Form', path: 'volunteer-form' },
   { key: 'attendees', label: 'Attendees', path: 'attendees', stub: true },
   { key: 'volunteers', label: 'Volunteers', path: 'volunteers', stub: true },
 ];

--- a/src/components/admin/BuiltinFieldsEditor.jsx
+++ b/src/components/admin/BuiltinFieldsEditor.jsx
@@ -1,0 +1,75 @@
+import { BUILTIN_FORM_FIELDS, BUILTIN_FORM_FIELD } from '../../constants/events';
+
+const FIELD_LABELS = {
+  [BUILTIN_FORM_FIELD.NAME]: 'Full Name',
+  [BUILTIN_FORM_FIELD.EMAIL]: 'Email',
+  [BUILTIN_FORM_FIELD.PHONE]: 'Phone',
+};
+
+const BuiltinFieldsEditor = ({ builtinFields = [], onChange }) => {
+  const isEnabled = field => builtinFields.some(item => item.field === field);
+
+  const isRequired = field => {
+    const item = builtinFields.find(entry => entry.field === field);
+    return item?.required ?? false;
+  };
+
+  const toggleField = field => {
+    if (isEnabled(field)) {
+      onChange(builtinFields.filter(item => item.field !== field));
+      return;
+    }
+    onChange([...builtinFields, { field, required: field !== BUILTIN_FORM_FIELD.PHONE }]);
+  };
+
+  const toggleRequired = field => {
+    onChange(
+      builtinFields.map(item =>
+        item.field === field ? { ...item, required: !item.required } : item
+      )
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-gray-900">Identity fields</h3>
+      <p className="text-xs text-gray-500">
+        Choose which contact fields appear on the form and whether each is required.
+      </p>
+      <ul className="space-y-2">
+        {BUILTIN_FORM_FIELDS.map(field => {
+          const enabled = isEnabled(field);
+          return (
+            <li
+              key={field}
+              className="flex flex-wrap items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+            >
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={() => toggleField(field)}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+                {FIELD_LABELS[field]}
+              </label>
+              {enabled && (
+                <label className="flex items-center gap-2 text-sm text-gray-600 ml-auto">
+                  <input
+                    type="checkbox"
+                    checked={isRequired(field)}
+                    onChange={() => toggleRequired(field)}
+                    className="h-4 w-4 rounded border-gray-300"
+                  />
+                  Required
+                </label>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default BuiltinFieldsEditor;

--- a/src/components/admin/CustomQuestionsEditor.jsx
+++ b/src/components/admin/CustomQuestionsEditor.jsx
@@ -1,0 +1,161 @@
+import { FORM_QUESTION_TYPE, FORM_QUESTION_TYPES } from '../../constants/events';
+
+const TYPE_LABELS = {
+  [FORM_QUESTION_TYPE.TEXT]: 'Short text',
+  [FORM_QUESTION_TYPE.TEXTAREA]: 'Long text',
+  [FORM_QUESTION_TYPE.SELECT]: 'Dropdown',
+  [FORM_QUESTION_TYPE.CHECKBOX]: 'Checkbox',
+};
+
+const createQuestionId = () => `q_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+
+const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
+  const addQuestion = () => {
+    onChange([
+      ...customQuestions,
+      {
+        id: createQuestionId(),
+        label: 'New question',
+        type: FORM_QUESTION_TYPE.TEXT,
+        required: false,
+        options: [],
+      },
+    ]);
+  };
+
+  const updateQuestion = (index, patch) => {
+    onChange(customQuestions.map((q, i) => (i === index ? { ...q, ...patch } : q)));
+  };
+
+  const removeQuestion = index => {
+    onChange(customQuestions.filter((_, i) => i !== index));
+  };
+
+  const moveQuestion = (index, direction) => {
+    const target = index + direction;
+    if (target < 0 || target >= customQuestions.length) return;
+    const next = [...customQuestions];
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+  };
+
+  const updateOptions = (index, raw) => {
+    const options = raw
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+    updateQuestion(index, { options });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium text-gray-900">Custom questions</h3>
+          <p className="text-xs text-gray-500">
+            Add optional questions beyond the identity fields.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={addQuestion}
+          className="px-3 py-1.5 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+        >
+          Add question
+        </button>
+      </div>
+
+      {customQuestions.length === 0 ? (
+        <p className="text-sm text-gray-500 italic">No custom questions yet.</p>
+      ) : (
+        <ul className="space-y-4">
+          {customQuestions.map((question, index) => (
+            <li key={question.id} className="rounded-lg border border-gray-200 p-4 space-y-3">
+              <div className="flex flex-wrap items-start gap-3">
+                <div className="flex-1 min-w-[200px]">
+                  <label className="block text-xs text-gray-500 mb-1">Label</label>
+                  <input
+                    type="text"
+                    value={question.label}
+                    onChange={e => updateQuestion(index, { label: e.target.value })}
+                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md"
+                  />
+                </div>
+                <div className="w-40">
+                  <label className="block text-xs text-gray-500 mb-1">Type</label>
+                  <select
+                    value={question.type}
+                    onChange={e => {
+                      const type = e.target.value;
+                      const patch = { type };
+                      if (type === FORM_QUESTION_TYPE.SELECT && !question.options?.length) {
+                        patch.options = ['Option 1'];
+                      }
+                      updateQuestion(index, patch);
+                    }}
+                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md"
+                  >
+                    {FORM_QUESTION_TYPES.map(type => (
+                      <option key={type} value={type}>
+                        {TYPE_LABELS[type]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <label className="flex items-center gap-2 text-sm text-gray-600 pt-6">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(question.required)}
+                    onChange={e => updateQuestion(index, { required: e.target.checked })}
+                    className="h-4 w-4 rounded border-gray-300"
+                  />
+                  Required
+                </label>
+              </div>
+
+              {question.type === FORM_QUESTION_TYPE.SELECT && (
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">Options (one per line)</label>
+                  <textarea
+                    rows={3}
+                    value={(question.options || []).join('\n')}
+                    onChange={e => updateOptions(index, e.target.value)}
+                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md"
+                  />
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  disabled={index === 0}
+                  onClick={() => moveQuestion(index, -1)}
+                  className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                >
+                  Move up
+                </button>
+                <button
+                  type="button"
+                  disabled={index === customQuestions.length - 1}
+                  onClick={() => moveQuestion(index, 1)}
+                  className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                >
+                  Move down
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeQuestion(index)}
+                  className="px-2 py-1 text-xs text-red-600 bg-red-50 rounded hover:bg-red-100 ml-auto"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default CustomQuestionsEditor;

--- a/src/components/admin/EventFormBuilder.jsx
+++ b/src/components/admin/EventFormBuilder.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import BuiltinFieldsEditor from './BuiltinFieldsEditor';
+import CustomQuestionsEditor from './CustomQuestionsEditor';
+import FormPreview from './FormPreview';
+import { BUILTIN_FORM_FIELD } from '../../constants/events';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+export const DEFAULT_FORM_SCHEMA = {
+  builtinFields: [
+    { field: BUILTIN_FORM_FIELD.NAME, required: true },
+    { field: BUILTIN_FORM_FIELD.EMAIL, required: true },
+  ],
+  customQuestions: [],
+};
+
+const EventFormBuilder = ({
+  title,
+  description,
+  identityKey = 'guestInfo',
+  initialSchema,
+  isLoading,
+  loadError,
+  onSave,
+  isSaving,
+}) => {
+  const [schema, setSchema] = useState(DEFAULT_FORM_SCHEMA);
+  const [saveError, setSaveError] = useState(null);
+
+  useEffect(() => {
+    if (initialSchema) {
+      setSchema({
+        builtinFields: initialSchema.builtinFields ?? DEFAULT_FORM_SCHEMA.builtinFields,
+        customQuestions: initialSchema.customQuestions ?? [],
+      });
+    }
+  }, [initialSchema]);
+
+  const handleSave = async () => {
+    if (!schema.builtinFields.length) {
+      setSaveError('At least one identity field must be enabled.');
+      return;
+    }
+    setSaveError(null);
+    try {
+      await onSave(schema);
+      showSuccessToast('Form saved');
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to save form';
+      setSaveError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading form…</p>;
+  }
+
+  if (loadError) {
+    return <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{loadError}</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        {description && <p className="text-sm text-gray-500 mt-1">{description}</p>}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="space-y-6 bg-white rounded-lg border border-gray-200 p-4">
+          <BuiltinFieldsEditor
+            builtinFields={schema.builtinFields}
+            onChange={builtinFields => setSchema(prev => ({ ...prev, builtinFields }))}
+          />
+          <CustomQuestionsEditor
+            customQuestions={schema.customQuestions}
+            onChange={customQuestions => setSchema(prev => ({ ...prev, customQuestions }))}
+          />
+        </div>
+        <FormPreview formSchema={schema} identityKey={identityKey} />
+      </div>
+
+      {saveError && (
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{saveError}</div>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          disabled={isSaving}
+          onClick={handleSave}
+          className="px-4 py-2 text-sm bg-msq-purple-rich text-white rounded-md hover:bg-msq-purple-deep disabled:opacity-50"
+        >
+          {isSaving ? 'Saving…' : 'Save form'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EventFormBuilder;

--- a/src/components/admin/FormPreview.jsx
+++ b/src/components/admin/FormPreview.jsx
@@ -1,0 +1,10 @@
+import DynamicEventForm from '../events/DynamicEventForm';
+
+const FormPreview = ({ formSchema, identityKey = 'guestInfo' }) => (
+  <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+    <h3 className="text-sm font-medium text-gray-900 mb-3">Preview</h3>
+    <DynamicEventForm formSchema={formSchema} identityKey={identityKey} readOnly />
+  </div>
+);
+
+export default FormPreview;

--- a/src/components/events/README.md
+++ b/src/components/events/README.md
@@ -1,0 +1,19 @@
+# Event form schema
+
+Registration and volunteer forms share the same schema shape consumed by `DynamicEventForm`:
+
+```js
+{
+  builtinFields: [{ field: 'name' | 'email' | 'phone', required: boolean }],
+  customQuestions: [
+    { id, label, type: 'text' | 'textarea' | 'select' | 'checkbox', required, options? }
+  ]
+}
+```
+
+- **Registration forms** use `identityKey="guestInfo"` — answers live under `guestInfo` at submit time.
+- **Volunteer forms** use `identityKey="applicantInfo"` — same builtin fields, different payload key.
+
+Admin editing lives in `EventFormBuilder` (preview + save via `upsertAdminRegistrationForm` / `upsertAdminVolunteerForm`). `DynamicEventForm` is read-only in Branch 4; interactive validation and submission arrive in later branches.
+
+Select questions require at least one option before save (backend enforced). Question `id` values must stay stable once the form is published so existing answers remain addressable.

--- a/src/pages/admin/AdminEventRegistrationForm.jsx
+++ b/src/pages/admin/AdminEventRegistrationForm.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import AdminEventDetailLayout from '../../components/admin/AdminEventDetailLayout';
+import EventFormBuilder from '../../components/admin/EventFormBuilder';
+import { useAdminEvent, useAdminEventRegistrationForm } from '../../hooks/queries/useAdmin';
+import {
+  useUpdateAdminEventStatus,
+  useUpsertAdminRegistrationForm,
+} from '../../hooks/mutations/useEventMutations';
+import { EVENT_STATUS, EVENT_TYPE } from '../../constants/events';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const AdminEventRegistrationForm = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const updateStatus = useUpdateAdminEventStatus();
+  const upsertForm = useUpsertAdminRegistrationForm();
+  const [statusError, setStatusError] = useState(null);
+
+  const { data: eventData, isLoading, isError, error } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  const {
+    data: formData,
+    isLoading: formLoading,
+    isError: formIsError,
+    error: formError,
+  } = useAdminEventRegistrationForm(id);
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load event'
+    : null;
+
+  const formLoadError = formIsError
+    ? formError?.response?.data?.error || formError?.message || 'Failed to load registration form'
+    : null;
+
+  const ticketTypes = event?.ticketTypes || [];
+  const hasActiveTickets = ticketTypes.some(t => t.isActive);
+  const showPaidTicketWarning =
+    event?.type === EVENT_TYPE.PAID && event?.status === EVENT_STATUS.DRAFT && !hasActiveTickets;
+
+  const handleStatusChange = async newStatus => {
+    const labels = { [EVENT_STATUS.PUBLISHED]: 'publish', [EVENT_STATUS.CANCELLED]: 'cancel' };
+    const action = labels[newStatus] || 'update';
+    if (!window.confirm(`Are you sure you want to ${action} this event?`)) return;
+    setStatusError(null);
+    try {
+      await updateStatus.mutateAsync({ id, status: newStatus });
+      showSuccessToast(`Event ${action === 'publish' ? 'published' : `${action}led`}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update status';
+      setStatusError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg || !event)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to events
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Event not found.'}
+        </div>
+      </div>
+    );
+
+  return (
+    <AdminEventDetailLayout
+      event={event}
+      eventId={id}
+      onBack={() => navigate('/admin/events')}
+      onEdit={() => navigate(`/admin/events/${id}/edit`)}
+      canPublish={event.status === EVENT_STATUS.DRAFT}
+      canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}
+      onPublish={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
+      onCancel={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
+      isUpdatingStatus={updateStatus.isPending}
+      showPaidTicketWarning={showPaidTicketWarning}
+      statusError={statusError}
+    >
+      <EventFormBuilder
+        title="Registration form"
+        description="Configure the fields guests fill out when registering for this event."
+        identityKey="guestInfo"
+        initialSchema={formData?.data}
+        isLoading={formLoading}
+        loadError={formLoadError}
+        isSaving={upsertForm.isPending}
+        onSave={schema => upsertForm.mutateAsync({ id, formSchema: schema })}
+      />
+    </AdminEventDetailLayout>
+  );
+};
+
+export default AdminEventRegistrationForm;

--- a/src/pages/admin/AdminEventVolunteerForm.jsx
+++ b/src/pages/admin/AdminEventVolunteerForm.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import AdminEventDetailLayout from '../../components/admin/AdminEventDetailLayout';
+import EventFormBuilder from '../../components/admin/EventFormBuilder';
+import { useAdminEvent, useAdminEventVolunteerForm } from '../../hooks/queries/useAdmin';
+import {
+  useUpdateAdminEventStatus,
+  useUpsertAdminVolunteerForm,
+} from '../../hooks/mutations/useEventMutations';
+import { EVENT_STATUS, EVENT_TYPE } from '../../constants/events';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const AdminEventVolunteerForm = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const updateStatus = useUpdateAdminEventStatus();
+  const upsertForm = useUpsertAdminVolunteerForm();
+  const [statusError, setStatusError] = useState(null);
+
+  const { data: eventData, isLoading, isError, error } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  const {
+    data: formData,
+    isLoading: formLoading,
+    isError: formIsError,
+    error: formError,
+  } = useAdminEventVolunteerForm(id);
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load event'
+    : null;
+
+  const formLoadError = formIsError
+    ? formError?.response?.data?.error || formError?.message || 'Failed to load volunteer form'
+    : null;
+
+  const ticketTypes = event?.ticketTypes || [];
+  const hasActiveTickets = ticketTypes.some(t => t.isActive);
+  const showPaidTicketWarning =
+    event?.type === EVENT_TYPE.PAID && event?.status === EVENT_STATUS.DRAFT && !hasActiveTickets;
+
+  const handleStatusChange = async newStatus => {
+    const labels = { [EVENT_STATUS.PUBLISHED]: 'publish', [EVENT_STATUS.CANCELLED]: 'cancel' };
+    const action = labels[newStatus] || 'update';
+    if (!window.confirm(`Are you sure you want to ${action} this event?`)) return;
+    setStatusError(null);
+    try {
+      await updateStatus.mutateAsync({ id, status: newStatus });
+      showSuccessToast(`Event ${action === 'publish' ? 'published' : `${action}led`}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update status';
+      setStatusError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg || !event)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to events
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Event not found.'}
+        </div>
+      </div>
+    );
+
+  return (
+    <AdminEventDetailLayout
+      event={event}
+      eventId={id}
+      onBack={() => navigate('/admin/events')}
+      onEdit={() => navigate(`/admin/events/${id}/edit`)}
+      canPublish={event.status === EVENT_STATUS.DRAFT}
+      canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}
+      onPublish={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
+      onCancel={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
+      isUpdatingStatus={updateStatus.isPending}
+      showPaidTicketWarning={showPaidTicketWarning}
+      statusError={statusError}
+    >
+      <EventFormBuilder
+        title="Volunteer form"
+        description="Configure the fields applicants fill out when applying to volunteer."
+        identityKey="applicantInfo"
+        initialSchema={formData?.data}
+        isLoading={formLoading}
+        loadError={formLoadError}
+        isSaving={upsertForm.isPending}
+        onSave={schema => upsertForm.mutateAsync({ id, formSchema: schema })}
+      />
+    </AdminEventDetailLayout>
+  );
+};
+
+export default AdminEventVolunteerForm;


### PR DESCRIPTION
Add admin-facing form builders so staff can configure registration and volunteer application fields per event. Mirrors the ticket panel pattern on event detail with live preview via the shared DynamicEventForm renderer.

- Add BuiltinFieldsEditor and CustomQuestionsEditor (text, textarea, select, checkbox)
- Add EventFormBuilder with FormPreview and GET/PUT save via existing admin hooks
- Wire Registration Form and Volunteer Form tabs with routes under /admin/events/:id
- Document form schema shape and identityKey usage in src/components/events/README.md
