### PR TITLE
Add admin event attendees dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,6 +55,8 @@ const AdminEventEdit = lazy(() => import('./pages/admin/AdminEventEdit'));
 const AdminEventTickets = lazy(() => import('./pages/admin/AdminEventTickets'));
 const AdminEventRegistrationForm = lazy(() => import('./pages/admin/AdminEventRegistrationForm'));
 const AdminEventVolunteerForm = lazy(() => import('./pages/admin/AdminEventVolunteerForm'));
+const AdminEventAttendees = lazy(() => import('./pages/admin/AdminEventAttendees'));
+const AdminEventAttendeeDetail = lazy(() => import('./pages/admin/AdminEventAttendeeDetail'));
 
 const App = () => {
   return (
@@ -392,6 +394,22 @@ const App = () => {
             element={
               <Suspense fallback={<PageLoader />}>
                 <AdminEventVolunteerForm />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/attendees/:registrationId"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventAttendeeDetail />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/attendees"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventAttendees />
               </Suspense>
             }
           />

--- a/src/components/admin/AdminEventDetailLayout.jsx
+++ b/src/components/admin/AdminEventDetailLayout.jsx
@@ -7,7 +7,7 @@ export const DETAIL_TABS = [
   { key: 'tickets', label: 'Tickets', path: 'tickets', paidOnly: true },
   { key: 'registration-form', label: 'Registration Form', path: 'registration-form' },
   { key: 'volunteer-form', label: 'Volunteer Form', path: 'volunteer-form' },
-  { key: 'attendees', label: 'Attendees', path: 'attendees', stub: true },
+  { key: 'attendees', label: 'Attendees', path: 'attendees' },
   { key: 'volunteers', label: 'Volunteers', path: 'volunteers', stub: true },
 ];
 

--- a/src/pages/admin/AdminEventAttendeeDetail.jsx
+++ b/src/pages/admin/AdminEventAttendeeDetail.jsx
@@ -1,0 +1,219 @@
+import { useMemo } from 'react';
+import { Link, useParams, useNavigate } from 'react-router';
+import DynamicEventForm from '../../components/events/DynamicEventForm';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import {
+  useAdminEvent,
+  useAdminEventAttendee,
+  useAdminEventRegistrationForm,
+} from '../../hooks/queries/useAdmin';
+import { EVENT_TYPE, REGISTRATION_STATUS_LABELS } from '../../constants/events';
+import { getRegistrationStatusColor } from '../../utils/events/statusBadges';
+import { pesewasToGhs } from '../../utils/events';
+import { formatCurrency } from '../../utils/admin/tableHelpers';
+
+const getGuestField = (registration, field) =>
+  registration?.guestInfo?.[field] ||
+  (field === 'name'
+    ? registration?.user?.displayName
+    : field === 'email'
+      ? registration?.user?.email
+      : field === 'phone'
+        ? registration?.user?.contact?.phone
+        : '') ||
+  '—';
+
+const AdminEventAttendeeDetail = () => {
+  const { id, registrationId } = useParams();
+  const navigate = useNavigate();
+
+  const { data: eventData, isLoading: eventLoading } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  const {
+    data: registrationData,
+    isLoading: registrationLoading,
+    isError,
+    error,
+  } = useAdminEventAttendee(id, registrationId);
+
+  const { data: formData, isLoading: formLoading } = useAdminEventRegistrationForm(id);
+
+  const registration = registrationData?.data || null;
+  const formSchema = formData?.data || null;
+
+  const ticketType = useMemo(() => {
+    if (!registration?.ticketTypeId || !event?.ticketTypes?.length) return null;
+    const ticketId = String(registration.ticketTypeId);
+    return event.ticketTypes.find(t => String(t._id) === ticketId) || null;
+  }, [registration?.ticketTypeId, event?.ticketTypes]);
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load registration'
+    : null;
+
+  const loading = eventLoading || registrationLoading;
+
+  if (loading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg || !registration)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate(`/admin/events/${id}/attendees`)}
+        >
+          Back to attendees
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Registration not found.'}
+        </div>
+      </div>
+    );
+
+  const transaction = registration.transaction;
+  const shortRegId = registration._id ? `#${String(registration._id).slice(-6)}` : '—';
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <button
+          className="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate(`/admin/events/${id}/attendees`)}
+        >
+          Back to attendees
+        </button>
+        {event && (
+          <Link
+            to={`/admin/events/${id}`}
+            className="text-sm text-msq-purple-rich hover:opacity-80"
+          >
+            View event: {event.name}
+          </Link>
+        )}
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
+          Registration {shortRegId}
+        </h1>
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full capitalize ${getRegistrationStatusColor(registration.status)}`}
+        >
+          {REGISTRATION_STATUS_LABELS[registration.status] || registration.status}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <h3 className="font-medium text-gray-900 mb-3">Guest information</h3>
+          <dl className="space-y-2 text-sm">
+            <div>
+              <dt className="text-gray-500">Name</dt>
+              <dd className="text-gray-900">{getGuestField(registration, 'name')}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Email</dt>
+              <dd className="text-gray-900">{getGuestField(registration, 'email')}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Phone</dt>
+              <dd className="text-gray-900">{getGuestField(registration, 'phone')}</dd>
+            </div>
+            {registration.user && (
+              <div>
+                <dt className="text-gray-500">Account</dt>
+                <dd>
+                  <Link
+                    to={`/admin/users/${registration.user._id}`}
+                    className="text-msq-purple-rich hover:opacity-80"
+                  >
+                    {registration.user.displayName || registration.user.email || 'View user'}
+                  </Link>
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <h3 className="font-medium text-gray-900 mb-3">Ticket & payment</h3>
+          <dl className="space-y-2 text-sm">
+            <div>
+              <dt className="text-gray-500">Ticket type</dt>
+              <dd className="text-gray-900">
+                {ticketType?.name || (event?.type === EVENT_TYPE.FREE ? 'Free registration' : '—')}
+              </dd>
+            </div>
+            {ticketType?.pricePesewas != null && (
+              <div>
+                <dt className="text-gray-500">Ticket price</dt>
+                <dd className="text-gray-900">
+                  {formatCurrency(pesewasToGhs(ticketType.pricePesewas))}
+                </dd>
+              </div>
+            )}
+            {transaction ? (
+              <>
+                <div>
+                  <dt className="text-gray-500">Payment status</dt>
+                  <dd className="text-gray-900 capitalize">{transaction.status || '—'}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Amount</dt>
+                  <dd className="text-gray-900">
+                    {transaction.amount != null
+                      ? formatCurrency(pesewasToGhs(transaction.amount))
+                      : '—'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Reference</dt>
+                  <dd className="text-gray-900 break-all font-mono text-xs">
+                    {transaction.reference || '—'}
+                  </dd>
+                </div>
+              </>
+            ) : (
+              <div>
+                <dt className="text-gray-500">Payment</dt>
+                <dd className="text-gray-900">No payment (free event)</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
+        <h3 className="font-medium text-gray-900 mb-3">Form responses</h3>
+        {formLoading ? (
+          <div className="flex justify-center py-6">
+            <LoadingSpinner size={32} />
+          </div>
+        ) : (
+          <DynamicEventForm
+            formSchema={formSchema}
+            identityKey="guestInfo"
+            values={{
+              guestInfo: registration.guestInfo,
+              formResponses: registration.formResponses,
+            }}
+            readOnly
+          />
+        )}
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 text-sm text-gray-500">
+        <p>Registered: {new Date(registration.createdAt).toLocaleString()}</p>
+        <p>Updated: {new Date(registration.updatedAt).toLocaleString()}</p>
+      </div>
+    </div>
+  );
+};
+
+export default AdminEventAttendeeDetail;

--- a/src/pages/admin/AdminEventAttendees.jsx
+++ b/src/pages/admin/AdminEventAttendees.jsx
@@ -1,0 +1,259 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import DataTable from '../../components/admin/DataTable';
+import { ViewButton } from '../../components/admin/ActionButton';
+import PaginationLocal from '../../components/orders/PaginationLocal';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import AdminEventDetailLayout from '../../components/admin/AdminEventDetailLayout';
+import { useAdminEvent, useAdminEventAttendees } from '../../hooks/queries/useAdmin';
+import { useUpdateAdminEventStatus } from '../../hooks/mutations/useEventMutations';
+import {
+  EVENT_STATUS,
+  EVENT_TYPE,
+  REGISTRATION_STATUSES,
+  REGISTRATION_STATUS_LABELS,
+} from '../../constants/events';
+import { getRegistrationStatusColor } from '../../utils/events/statusBadges';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  ...REGISTRATION_STATUSES.map(value => ({
+    value,
+    label: REGISTRATION_STATUS_LABELS[value],
+  })),
+];
+
+const getGuestName = row => row.guestInfo?.name || row.user?.displayName || '—';
+const getGuestEmail = row => row.guestInfo?.email || row.user?.email || '—';
+
+const getTicketTypeName = (ticketTypeId, ticketTypes = []) => {
+  if (!ticketTypeId) return '—';
+  const id = String(ticketTypeId);
+  const match = ticketTypes.find(t => String(t._id) === id);
+  return match?.name || '—';
+};
+
+const AdminEventAttendees = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const updateStatus = useUpdateAdminEventStatus();
+  const [statusError, setStatusError] = useState(null);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+  const [status, setStatus] = useState('');
+  const [ticketTypeId, setTicketTypeId] = useState('');
+
+  const { data: eventData, isLoading, isError, error } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  useEffect(() => {
+    setPage(1);
+  }, [status, ticketTypeId]);
+
+  const params = { page, limit };
+  if (status) params.status = status;
+  if (ticketTypeId) params.ticketTypeId = ticketTypeId;
+
+  const {
+    data: attendeesData,
+    isLoading: attendeesLoading,
+    isError: attendeesIsError,
+    error: attendeesError,
+  } = useAdminEventAttendees(id, params);
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load event'
+    : null;
+
+  const attendeesErrMsg = attendeesIsError
+    ? attendeesError?.response?.data?.error || attendeesError?.message || 'Failed to load attendees'
+    : null;
+
+  const ticketTypes = useMemo(() => event?.ticketTypes || [], [event?.ticketTypes]);
+  const hasActiveTickets = ticketTypes.some(t => t.isActive);
+  const showPaidTicketWarning =
+    event?.type === EVENT_TYPE.PAID && event?.status === EVENT_STATUS.DRAFT && !hasActiveTickets;
+
+  const ticketTypeOptions = useMemo(
+    () => [
+      { value: '', label: 'All ticket types' },
+      ...ticketTypes.map(t => ({ value: t._id, label: t.name })),
+    ],
+    [ticketTypes]
+  );
+
+  const rawList = attendeesData?.data || [];
+  const list = rawList.map(item => ({ ...item, id: item._id }));
+  const totalPages = attendeesData?.totalPages || attendeesData?.pagination?.totalPages || 1;
+
+  const handleStatusChange = async newStatus => {
+    const labels = { [EVENT_STATUS.PUBLISHED]: 'publish', [EVENT_STATUS.CANCELLED]: 'cancel' };
+    const action = labels[newStatus] || 'update';
+    if (!window.confirm(`Are you sure you want to ${action} this event?`)) return;
+    setStatusError(null);
+    try {
+      await updateStatus.mutateAsync({ id, status: newStatus });
+      showSuccessToast(`Event ${action === 'publish' ? 'published' : `${action}led`}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update status';
+      setStatusError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  const columns = [
+    {
+      key: 'guestInfo',
+      label: 'Guest',
+      render: (_v, row) => (
+        <div>
+          <p className="font-medium text-gray-900">{getGuestName(row)}</p>
+          <p className="text-xs text-gray-500">{getGuestEmail(row)}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: v => (
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full capitalize ${getRegistrationStatusColor(v)}`}
+        >
+          {REGISTRATION_STATUS_LABELS[v] || v || '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'ticketTypeId',
+      label: 'Ticket type',
+      render: v => (
+        <span className="text-sm text-gray-700">{getTicketTypeName(v, ticketTypes)}</span>
+      ),
+    },
+    {
+      key: 'transaction',
+      label: 'Payment',
+      render: (_v, row) => {
+        const tx = row.transaction;
+        if (!tx) return <span className="text-sm text-gray-500">Free</span>;
+        return (
+          <span className="text-sm text-gray-700 capitalize">
+            {tx.status || '—'}
+            {tx.reference ? ` · ${tx.reference.slice(-8)}` : ''}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'createdAt',
+      label: 'Registered',
+      render: v => (v ? new Date(v).toLocaleString() : '—'),
+    },
+  ];
+
+  const actions = [
+    {
+      component: ViewButton,
+      onClick: row => navigate(`/admin/events/${id}/attendees/${row._id}`),
+      title: 'View',
+    },
+  ];
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg || !event)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to events
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Event not found.'}
+        </div>
+      </div>
+    );
+
+  return (
+    <AdminEventDetailLayout
+      event={event}
+      eventId={id}
+      onBack={() => navigate('/admin/events')}
+      onEdit={() => navigate(`/admin/events/${id}/edit`)}
+      canPublish={event.status === EVENT_STATUS.DRAFT}
+      canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}
+      onPublish={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
+      onCancel={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
+      isUpdatingStatus={updateStatus.isPending}
+      showPaidTicketWarning={showPaidTicketWarning}
+      statusError={statusError}
+    >
+      <div>
+        <h2 className="text-lg font-medium text-gray-900 mb-4">Attendees</h2>
+
+        <div className="mb-4 p-4 bg-white rounded-lg border border-gray-200">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <select
+              value={status}
+              onChange={e => setStatus(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich"
+            >
+              {STATUS_OPTIONS.map(o => (
+                <option key={o.value || 'all'} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+            {event.type === EVENT_TYPE.PAID && ticketTypeOptions.length > 1 && (
+              <select
+                value={ticketTypeId}
+                onChange={e => setTicketTypeId(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich"
+              >
+                {ticketTypeOptions.map(o => (
+                  <option key={o.value || 'all'} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </div>
+
+        {attendeesErrMsg && (
+          <div className="mb-4 p-3 rounded-md bg-red-50 text-red-600 text-sm">
+            {attendeesErrMsg}
+          </div>
+        )}
+
+        {attendeesLoading ? (
+          <div className="flex justify-center py-12">
+            <LoadingSpinner size={48} />
+          </div>
+        ) : (
+          <>
+            <DataTable columns={columns} data={list} actions={actions} />
+            {totalPages > 1 && (
+              <PaginationLocal
+                page={page}
+                totalPages={totalPages}
+                onPrev={() => setPage(p => Math.max(1, p - 1))}
+                onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </AdminEventDetailLayout>
+  );
+};
+
+export default AdminEventAttendees;


### PR DESCRIPTION
Add admin-facing attendee dashboards so staff can review event registrations from the event detail hub. Lists support status and ticket-type filters with pagination; the detail view shows guest info, form answers, and payment references.

- Add AdminEventAttendees list with DataTable, status/ticketTypeId filters, and pagination
- Add AdminEventAttendeeDetail with guest info, ticket type, DynamicEventForm answers, and transaction details
- Enable Attendees tab and register /admin/events/:id/attendees routes in App.jsx
