### PR TITLE
Add admin volunteer applications dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,6 +57,8 @@ const AdminEventRegistrationForm = lazy(() => import('./pages/admin/AdminEventRe
 const AdminEventVolunteerForm = lazy(() => import('./pages/admin/AdminEventVolunteerForm'));
 const AdminEventAttendees = lazy(() => import('./pages/admin/AdminEventAttendees'));
 const AdminEventAttendeeDetail = lazy(() => import('./pages/admin/AdminEventAttendeeDetail'));
+const AdminEventVolunteers = lazy(() => import('./pages/admin/AdminEventVolunteers'));
+const AdminEventVolunteerDetail = lazy(() => import('./pages/admin/AdminEventVolunteerDetail'));
 
 const App = () => {
   return (
@@ -410,6 +412,22 @@ const App = () => {
             element={
               <Suspense fallback={<PageLoader />}>
                 <AdminEventAttendees />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/volunteers/:applicationId"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventVolunteerDetail />
+              </Suspense>
+            }
+          />
+          <Route
+            path="events/:id/volunteers"
+            element={
+              <Suspense fallback={<PageLoader />}>
+                <AdminEventVolunteers />
               </Suspense>
             }
           />

--- a/src/components/admin/AdminEventDetailLayout.jsx
+++ b/src/components/admin/AdminEventDetailLayout.jsx
@@ -8,7 +8,7 @@ export const DETAIL_TABS = [
   { key: 'registration-form', label: 'Registration Form', path: 'registration-form' },
   { key: 'volunteer-form', label: 'Volunteer Form', path: 'volunteer-form' },
   { key: 'attendees', label: 'Attendees', path: 'attendees' },
-  { key: 'volunteers', label: 'Volunteers', path: 'volunteers', stub: true },
+  { key: 'volunteers', label: 'Volunteers', path: 'volunteers' },
 ];
 
 const AdminEventDetailLayout = ({

--- a/src/pages/admin/AdminEventVolunteerDetail.jsx
+++ b/src/pages/admin/AdminEventVolunteerDetail.jsx
@@ -1,0 +1,206 @@
+import { useState } from 'react';
+import { Link, useParams, useNavigate } from 'react-router';
+import DynamicEventForm from '../../components/events/DynamicEventForm';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import {
+  useAdminEvent,
+  useAdminVolunteerApplication,
+  useAdminEventVolunteerForm,
+} from '../../hooks/queries/useAdmin';
+import { useUpdateAdminVolunteerApplication } from '../../hooks/mutations/useEventMutations';
+import { VOLUNTEER_STATUS, VOLUNTEER_STATUS_LABELS } from '../../constants/events';
+import { getVolunteerStatusColor } from '../../utils/events/statusBadges';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const getApplicantField = (application, field) =>
+  application?.applicantInfo?.[field] ||
+  (field === 'name'
+    ? application?.user?.displayName
+    : field === 'email'
+      ? application?.user?.email
+      : field === 'phone'
+        ? application?.user?.contact?.phone
+        : '') ||
+  '—';
+
+const AdminEventVolunteerDetail = () => {
+  const { id, applicationId } = useParams();
+  const navigate = useNavigate();
+  const updateApplication = useUpdateAdminVolunteerApplication();
+  const [actionError, setActionError] = useState(null);
+
+  const { data: eventData, isLoading: eventLoading } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  const {
+    data: applicationData,
+    isLoading: applicationLoading,
+    isError,
+    error,
+  } = useAdminVolunteerApplication(id, applicationId);
+
+  const { data: formData, isLoading: formLoading } = useAdminEventVolunteerForm(id);
+
+  const application = applicationData?.data || null;
+  const formSchema = formData?.data || null;
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load application'
+    : null;
+
+  const loading = eventLoading || applicationLoading;
+  const isPending = application?.status === VOLUNTEER_STATUS.PENDING;
+
+  const handleStatusUpdate = async newStatus => {
+    const action = newStatus === VOLUNTEER_STATUS.ACCEPTED ? 'accept' : 'reject';
+    if (!window.confirm(`Are you sure you want to ${action} this volunteer application?`)) return;
+
+    setActionError(null);
+    try {
+      await updateApplication.mutateAsync({ eventId: id, applicationId, status: newStatus });
+      showSuccessToast(`Application ${action === 'accept' ? 'accepted' : 'rejected'}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || `Failed to ${action} application`;
+      setActionError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  if (loading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg || !application)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate(`/admin/events/${id}/volunteers`)}
+        >
+          Back to volunteers
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Application not found.'}
+        </div>
+      </div>
+    );
+
+  const shortAppId = application._id ? `#${String(application._id).slice(-6)}` : '—';
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <button
+          className="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate(`/admin/events/${id}/volunteers`)}
+        >
+          Back to volunteers
+        </button>
+        {event && (
+          <Link
+            to={`/admin/events/${id}`}
+            className="text-sm text-msq-purple-rich hover:opacity-80"
+          >
+            View event: {event.name}
+          </Link>
+        )}
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
+          Application {shortAppId}
+        </h1>
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full capitalize ${getVolunteerStatusColor(application.status)}`}
+        >
+          {VOLUNTEER_STATUS_LABELS[application.status] || application.status}
+        </span>
+      </div>
+
+      {actionError && (
+        <div className="mb-4 p-3 rounded-md bg-red-50 text-red-600 text-sm">{actionError}</div>
+      )}
+
+      {isPending && (
+        <div className="mb-6 flex flex-wrap gap-2">
+          <button
+            type="button"
+            disabled={updateApplication.isPending}
+            className="px-4 py-2 text-sm bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50"
+            onClick={() => handleStatusUpdate(VOLUNTEER_STATUS.ACCEPTED)}
+          >
+            Accept application
+          </button>
+          <button
+            type="button"
+            disabled={updateApplication.isPending}
+            className="px-4 py-2 text-sm bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
+            onClick={() => handleStatusUpdate(VOLUNTEER_STATUS.REJECTED)}
+          >
+            Reject application
+          </button>
+        </div>
+      )}
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6 max-w-lg">
+        <h3 className="font-medium text-gray-900 mb-3">Applicant information</h3>
+        <dl className="space-y-2 text-sm">
+          <div>
+            <dt className="text-gray-500">Name</dt>
+            <dd className="text-gray-900">{getApplicantField(application, 'name')}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Email</dt>
+            <dd className="text-gray-900">{getApplicantField(application, 'email')}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Phone</dt>
+            <dd className="text-gray-900">{getApplicantField(application, 'phone')}</dd>
+          </div>
+          {application.user && (
+            <div>
+              <dt className="text-gray-500">Account</dt>
+              <dd>
+                <Link
+                  to={`/admin/users/${application.user._id}`}
+                  className="text-msq-purple-rich hover:opacity-80"
+                >
+                  {application.user.displayName || application.user.email || 'View user'}
+                </Link>
+              </dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
+        <h3 className="font-medium text-gray-900 mb-3">Form responses</h3>
+        {formLoading ? (
+          <div className="flex justify-center py-6">
+            <LoadingSpinner size={32} />
+          </div>
+        ) : (
+          <DynamicEventForm
+            formSchema={formSchema}
+            identityKey="applicantInfo"
+            values={{
+              applicantInfo: application.applicantInfo,
+              formResponses: application.formResponses,
+            }}
+            readOnly
+          />
+        )}
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 text-sm text-gray-500">
+        <p>Applied: {new Date(application.createdAt).toLocaleString()}</p>
+        <p>Updated: {new Date(application.updatedAt).toLocaleString()}</p>
+      </div>
+    </div>
+  );
+};
+
+export default AdminEventVolunteerDetail;

--- a/src/pages/admin/AdminEventVolunteers.jsx
+++ b/src/pages/admin/AdminEventVolunteers.jsx
@@ -1,0 +1,208 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import DataTable from '../../components/admin/DataTable';
+import { ViewButton } from '../../components/admin/ActionButton';
+import PaginationLocal from '../../components/orders/PaginationLocal';
+import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
+import AdminEventDetailLayout from '../../components/admin/AdminEventDetailLayout';
+import { useAdminEvent, useAdminVolunteerApplications } from '../../hooks/queries/useAdmin';
+import { useUpdateAdminEventStatus } from '../../hooks/mutations/useEventMutations';
+import {
+  EVENT_STATUS,
+  EVENT_TYPE,
+  VOLUNTEER_STATUSES,
+  VOLUNTEER_STATUS_LABELS,
+} from '../../constants/events';
+import { getVolunteerStatusColor } from '../../utils/events/statusBadges';
+import { showSuccessToast, showErrorToast } from '../../utils/showToast';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  ...VOLUNTEER_STATUSES.map(value => ({
+    value,
+    label: VOLUNTEER_STATUS_LABELS[value],
+  })),
+];
+
+const getApplicantName = row => row.applicantInfo?.name || row.user?.displayName || '—';
+const getApplicantEmail = row => row.applicantInfo?.email || row.user?.email || '—';
+
+const AdminEventVolunteers = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const updateStatus = useUpdateAdminEventStatus();
+  const [statusError, setStatusError] = useState(null);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+  const [status, setStatus] = useState('');
+
+  const { data: eventData, isLoading, isError, error } = useAdminEvent(id);
+  const event = eventData?.data || null;
+
+  useEffect(() => {
+    setPage(1);
+  }, [status]);
+
+  const params = { page, limit };
+  if (status) params.status = status;
+
+  const {
+    data: applicationsData,
+    isLoading: applicationsLoading,
+    isError: applicationsIsError,
+    error: applicationsError,
+  } = useAdminVolunteerApplications(id, params);
+
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load event'
+    : null;
+
+  const applicationsErrMsg = applicationsIsError
+    ? applicationsError?.response?.data?.error ||
+      applicationsError?.message ||
+      'Failed to load volunteer applications'
+    : null;
+
+  const ticketTypes = event?.ticketTypes || [];
+  const hasActiveTickets = ticketTypes.some(t => t.isActive);
+  const showPaidTicketWarning =
+    event?.type === EVENT_TYPE.PAID && event?.status === EVENT_STATUS.DRAFT && !hasActiveTickets;
+
+  const rawList = applicationsData?.data || [];
+  const list = rawList.map(item => ({ ...item, id: item._id }));
+  const totalPages = applicationsData?.totalPages || applicationsData?.pagination?.totalPages || 1;
+
+  const handleStatusChange = async newStatus => {
+    const labels = { [EVENT_STATUS.PUBLISHED]: 'publish', [EVENT_STATUS.CANCELLED]: 'cancel' };
+    const action = labels[newStatus] || 'update';
+    if (!window.confirm(`Are you sure you want to ${action} this event?`)) return;
+    setStatusError(null);
+    try {
+      await updateStatus.mutateAsync({ id, status: newStatus });
+      showSuccessToast(`Event ${action === 'publish' ? 'published' : `${action}led`}`);
+    } catch (err) {
+      const msg = err?.response?.data?.error || err?.message || 'Failed to update status';
+      setStatusError(msg);
+      showErrorToast(msg);
+    }
+  };
+
+  const columns = [
+    {
+      key: 'applicantInfo',
+      label: 'Applicant',
+      render: (_v, row) => (
+        <div>
+          <p className="font-medium text-gray-900">{getApplicantName(row)}</p>
+          <p className="text-xs text-gray-500">{getApplicantEmail(row)}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: v => (
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full capitalize ${getVolunteerStatusColor(v)}`}
+        >
+          {VOLUNTEER_STATUS_LABELS[v] || v || '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'createdAt',
+      label: 'Applied',
+      render: v => (v ? new Date(v).toLocaleString() : '—'),
+    },
+  ];
+
+  const actions = [
+    {
+      component: ViewButton,
+      onClick: row => navigate(`/admin/events/${id}/volunteers/${row._id}`),
+      title: 'View',
+    },
+  ];
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size={48} />
+      </div>
+    );
+
+  if (errMsg || !event)
+    return (
+      <div>
+        <button
+          className="mb-4 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          onClick={() => navigate('/admin/events')}
+        >
+          Back to events
+        </button>
+        <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+          {errMsg || 'Event not found.'}
+        </div>
+      </div>
+    );
+
+  return (
+    <AdminEventDetailLayout
+      event={event}
+      eventId={id}
+      onBack={() => navigate('/admin/events')}
+      onEdit={() => navigate(`/admin/events/${id}/edit`)}
+      canPublish={event.status === EVENT_STATUS.DRAFT}
+      canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}
+      onPublish={() => handleStatusChange(EVENT_STATUS.PUBLISHED)}
+      onCancel={() => handleStatusChange(EVENT_STATUS.CANCELLED)}
+      isUpdatingStatus={updateStatus.isPending}
+      showPaidTicketWarning={showPaidTicketWarning}
+      statusError={statusError}
+    >
+      <div>
+        <h2 className="text-lg font-medium text-gray-900 mb-4">Volunteer applications</h2>
+
+        <div className="mb-4 p-4 bg-white rounded-lg border border-gray-200">
+          <select
+            value={status}
+            onChange={e => setStatus(e.target.value)}
+            className="w-full sm:w-auto px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich"
+          >
+            {STATUS_OPTIONS.map(o => (
+              <option key={o.value || 'all'} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {applicationsErrMsg && (
+          <div className="mb-4 p-3 rounded-md bg-red-50 text-red-600 text-sm">
+            {applicationsErrMsg}
+          </div>
+        )}
+
+        {applicationsLoading ? (
+          <div className="flex justify-center py-12">
+            <LoadingSpinner size={48} />
+          </div>
+        ) : (
+          <>
+            <DataTable columns={columns} data={list} actions={actions} />
+            {totalPages > 1 && (
+              <PaginationLocal
+                page={page}
+                totalPages={totalPages}
+                onPrev={() => setPage(p => Math.max(1, p - 1))}
+                onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </AdminEventDetailLayout>
+  );
+};
+
+export default AdminEventVolunteers;


### PR DESCRIPTION
Add admin-facing volunteer application management so staff can review applicants, filter by status, and accept or reject pending applications. Mirrors the attendees dashboard patterns and uses the existing volunteer API hooks from the events foundation.

- Add AdminEventVolunteers list with DataTable, status filter, and pagination
- Add AdminEventVolunteerDetail with applicant info, form answers, and accept/reject actions
- Wire /admin/events/:id/volunteers routes and enable Volunteers tab on event detail
