### PR TITLE
Add public events listing page and navbar link

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ const Register = lazy(() => import('./pages/Register'));
 const Login = lazy(() => import('./pages/Login'));
 const AuthCallback = lazy(() => import('./pages/auth/AuthCallback'));
 const Bespoke = lazy(() => import('./pages/Bespoke'));
+const Events = lazy(() => import('./pages/Events'));
 const CategoryPage = lazy(() => import('./pages/CategoryPage'));
 const ProductDetails = lazy(() => import('./pages/ProductDetails'));
 const Orders = lazy(() => import('./pages/Orders'));
@@ -109,6 +110,16 @@ const App = () => {
             </MainLayout>
           }
         ></Route>
+        <Route
+          path="/events"
+          element={
+            <MainLayout>
+              <Suspense fallback={<PageLoader />}>
+                <Events />
+              </Suspense>
+            </MainLayout>
+          }
+        />
         <Route
           path="/bespoke"
           element={

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -1,0 +1,69 @@
+import { memo } from 'react';
+import { Link } from 'react-router';
+import { Calendar, MapPin, Users } from 'lucide-react';
+
+import { EVENT_TYPE_LABELS } from '../../constants/events';
+import { formatEventDate, formatEventVenue } from '../../utils/events';
+import { getEventTypeColor } from '../../utils/events/statusBadges';
+
+const getSpotsLabel = spotsRemaining => {
+  if (spotsRemaining == null) return null;
+  if (spotsRemaining <= 0) return 'Full';
+  return `${spotsRemaining} spot${spotsRemaining !== 1 ? 's' : ''} remaining`;
+};
+
+const EventCard = ({ event }) => {
+  const bannerUrl = event.banner?.url;
+  const venueLabel = formatEventVenue(event.venue);
+  const spotsLabel = getSpotsLabel(event.spotsRemaining);
+
+  return (
+    <div className="bg-white border-none rounded-none w-full mx-auto">
+      <Link to={`/events/${event.slug}`} className="block group">
+        <div className="aspect-[3/4] w-full relative bg-gray-100 overflow-hidden">
+          {bannerUrl ? (
+            <img
+              src={bannerUrl}
+              alt={event.name}
+              className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 ease-in-out group-hover:scale-105"
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center bg-msq-gold-light/10">
+              <Calendar className="w-12 h-12 text-msq-purple-deep/30" aria-hidden="true" />
+            </div>
+          )}
+          <span
+            className={`absolute top-3 left-3 inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventTypeColor(event.type)}`}
+          >
+            {EVENT_TYPE_LABELS[event.type] || event.type}
+          </span>
+        </div>
+      </Link>
+      <div className="px-4 py-2">
+        <Link to={`/events/${event.slug}`}>
+          <h3 className="text-xs sm:text-xs md:text-sm lg:text-lg font-medium text-msq-purple uppercase text-left tracking-wide hover:text-msq-purple-rich transition-colors">
+            {event.name}
+          </h3>
+        </Link>
+        <p className="mt-1 text-xs sm:text-sm text-gray-600 flex items-start gap-1">
+          <Calendar className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+          <span>{formatEventDate(event.eventDate)}</span>
+        </p>
+        {venueLabel && (
+          <p className="mt-0.5 text-xs sm:text-sm text-gray-600 flex items-start gap-1">
+            <MapPin className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+            <span className="line-clamp-2">{venueLabel}</span>
+          </p>
+        )}
+        {spotsLabel && (
+          <p className="mt-1 text-xs sm:text-sm font-medium text-msq-purple-deep flex items-center gap-1">
+            <Users className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+            <span>{spotsLabel}</span>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default memo(EventCard);

--- a/src/components/layout/navigation/MobileMenu.jsx
+++ b/src/components/layout/navigation/MobileMenu.jsx
@@ -155,6 +155,16 @@ const MobileMenu = ({ isOpen, onClose }) => {
                   </MotionNavItem>
                   <MotionNavItem variants={navLinkItemVariants}>
                     <Link
+                      to="/events"
+                      onClick={onClose}
+                      className="block py-3 px-3 text-msq-purple-rich hover:bg-gray-100 rounded-lg transition-colors duration-200"
+                    >
+                      <div className="font-medium">Events</div>
+                      <div className="text-sm text-gray-500">Workshops, meetups & experiences</div>
+                    </Link>
+                  </MotionNavItem>
+                  <MotionNavItem variants={navLinkItemVariants}>
+                    <Link
                       to="/bespoke"
                       onClick={onClose}
                       className="block py-3 px-3 text-msq-purple-rich hover:bg-gray-100 rounded-lg transition-colors duration-200"

--- a/src/components/layout/navigation/NavLinks.jsx
+++ b/src/components/layout/navigation/NavLinks.jsx
@@ -6,6 +6,7 @@ const NavLinks = ({ className = '', tone = 'solid' }) => {
 
   const links = [
     { to: '/shop', label: 'Shop' },
+    { to: '/events', label: 'Events' },
     { to: '/bespoke', label: 'Bespoke' },
     { to: '/about-us', label: 'About' },
     { to: '/faqs', label: 'FAQs' },

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import ProductGrid from '../components/products/ProductGrid';
+import EventCard from '../components/events/EventCard';
+import PaginationLocal from '../components/orders/PaginationLocal';
+import SEO from '../components/SEO';
+import { LoadingSpinner } from '../components/ui/LoadingSpinner';
+import { useEvents } from '../hooks/queries/useEvents';
+import { EVENT_TYPES, EVENT_TYPE_LABELS } from '../constants/events';
+import scrollToTop from '../utils/scrollToTop';
+
+const TYPE_OPTIONS = [
+  { value: '', label: 'All events' },
+  ...EVENT_TYPES.map(value => ({ value, label: EVENT_TYPE_LABELS[value] })),
+];
+
+const EVENTS_PER_PAGE = 12;
+
+const Events = () => {
+  const [page, setPage] = useState(1);
+  const [type, setType] = useState('');
+  const [q, setQ] = useState('');
+
+  useEffect(() => {
+    setPage(1);
+  }, [q, type]);
+
+  const params = { page, limit: EVENTS_PER_PAGE };
+  if (q.trim()) params.q = q.trim();
+  if (type) params.type = type;
+
+  const { data, isLoading, isFetching, isError, error, refetch } = useEvents(params);
+
+  const events = useMemo(() => data?.data || [], [data?.data]);
+  const pagination = data?.pagination || {};
+  const totalPages = pagination.totalPages || 1;
+  const isGridLoading = isLoading || isFetching;
+  const isSearching = Boolean(q.trim() || type);
+  const errMsg = isError
+    ? error?.response?.data?.error || error?.message || 'Failed to load events'
+    : null;
+
+  useEffect(() => {
+    if (!isGridLoading && data) {
+      scrollToTop();
+    }
+  }, [isGridLoading, data]);
+
+  const eventCards = useMemo(
+    () => events.map(event => <EventCard key={event._id} event={event} />),
+    [events]
+  );
+
+  return (
+    <>
+      <SEO
+        title="Events"
+        description="Discover upcoming Misqabbi events — workshops, meetups, and exclusive experiences."
+        canonicalPath="/events"
+      />
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bebas text-msq-purple-rich">Upcoming Events</h1>
+          <p className="text-gray-600 mt-2">
+            Join us for workshops, gatherings, and experiences designed with you in mind.
+          </p>
+        </div>
+
+        <div className="mb-6 p-4 bg-white rounded-lg border border-gray-200">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <input
+              type="search"
+              placeholder="Search events"
+              value={q}
+              onChange={e => setQ(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich focus:border-msq-purple-rich"
+            />
+            <select
+              value={type}
+              onChange={e => setType(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich focus:border-msq-purple-rich"
+            >
+              {TYPE_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {isGridLoading ? (
+          <div className="flex justify-center py-12">
+            <LoadingSpinner size={48} />
+          </div>
+        ) : errMsg ? (
+          <div className="p-4 rounded-md border border-red-200 bg-red-50 text-red-700">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-sm">{errMsg}</span>
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="text-sm font-medium underline hover:opacity-80 shrink-0"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        ) : events.length === 0 ? (
+          <div className="p-8 text-center border border-gray-200 rounded-lg bg-white">
+            <div className="text-lg font-medium text-gray-900">No events found</div>
+            <p className="mt-2 text-sm text-gray-600">
+              {isSearching
+                ? 'Try adjusting your search or filters.'
+                : 'Check back soon for upcoming events.'}
+            </p>
+          </div>
+        ) : (
+          <>
+            {isSearching && (
+              <div className="mb-4 text-center">
+                <p className="text-gray-600">
+                  {events.length} result{events.length !== 1 ? 's' : ''} on this page
+                  {q.trim() && ` for "${q.trim()}"`}
+                </p>
+              </div>
+            )}
+            <ProductGrid>{eventCards}</ProductGrid>
+            {totalPages > 1 && (
+              <PaginationLocal
+                page={page}
+                totalPages={totalPages}
+                onPrev={() => setPage(p => Math.max(1, p - 1))}
+                onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+              />
+            )}
+          </>
+        )}
+      </main>
+    </>
+  );
+};
+
+export default Events;


### PR DESCRIPTION
Add a public events discovery page so visitors can browse published events with type and search filters. Uses the existing events API foundation and adds navbar navigation to /events.

- Add EventCard with banner, date, venue, type badge, and spots remaining
- Add Events listing page with type/q filters, pagination, and SEO
- Register /events route and add Events link to desktop and mobile navbar
