### PR TITLE
Add free event registration flow

### DIFF
--- a/src/components/events/DynamicEventForm.jsx
+++ b/src/components/events/DynamicEventForm.jsx
@@ -7,20 +7,25 @@ const BUILTIN_LABELS = {
 };
 
 /**
- * Read-only renderer for event registration/volunteer forms.
- * Used in admin preview and public submission (interactive mode added in later branches).
+ * Renders event registration/volunteer forms for admin preview and public submission.
  *
  * @param {Object} props
  * @param {Object} props.formSchema - { builtinFields, customQuestions }
- * @param {'guestInfo'|'applicantInfo'} [props.identityKey='guestInfo'] - Which identity block to show
- * @param {Object} [props.values] - Current field values (read-only display when readOnly=true)
- * @param {boolean} [props.readOnly=true] - Disable inputs (foundation skeleton)
+ * @param {'guestInfo'|'applicantInfo'} [props.identityKey='guestInfo']
+ * @param {Object} [props.values] - { guestInfo|applicantInfo, formResponses: { customAnswers } }
+ * @param {boolean} [props.readOnly=true]
+ * @param {Object} [props.errors] - { identity: { field: message }, customAnswers: { questionId: message } }
+ * @param {(field: string, value: string) => void} [props.onIdentityFieldChange]
+ * @param {(questionId: string, value: string|boolean) => void} [props.onCustomAnswerChange]
  */
 const DynamicEventForm = ({
   formSchema,
   identityKey = 'guestInfo',
   values = {},
   readOnly = true,
+  errors = {},
+  onIdentityFieldChange,
+  onCustomAnswerChange,
 }) => {
   if (!formSchema) {
     return <p className="text-sm text-gray-500">No form configured.</p>;
@@ -29,59 +34,102 @@ const DynamicEventForm = ({
   const { builtinFields = [], customQuestions = [] } = formSchema;
   const identityValues = values[identityKey] || values.guestInfo || values.applicantInfo || {};
   const customAnswers = values.formResponses?.customAnswers || values.customAnswers || {};
+  const identityErrors = errors.identity || {};
+  const customErrors = errors.customAnswers || {};
 
-  const inputClass =
-    'w-full px-3 py-2 border border-gray-200 rounded-md bg-gray-50 text-gray-700 text-sm';
-  const disabledProps = readOnly ? { disabled: true, readOnly: true } : {};
+  const baseInputClass =
+    'w-full px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-msq-purple-rich/30';
+  const readOnlyInputClass = `${baseInputClass} border-gray-200 bg-gray-50 text-gray-700`;
+  const interactiveInputClass = fieldError =>
+    `${baseInputClass} bg-white text-gray-900 ${fieldError ? 'border-red-500' : 'border-gray-300'}`;
 
-  const renderBuiltinField = ({ field, required }) => (
-    <div key={field} className="mb-4">
-      <label className="block text-sm font-medium text-gray-700 mb-1">
-        {BUILTIN_LABELS[field] || field}
-        {required && <span className="text-red-500 ml-1">*</span>}
-      </label>
-      <input
-        type={field === 'email' ? 'email' : field === 'phone' ? 'tel' : 'text'}
-        value={identityValues[field] ?? ''}
-        placeholder={BUILTIN_LABELS[field]}
-        className={inputClass}
-        {...disabledProps}
-      />
-    </div>
-  );
+  const renderBuiltinField = ({ field, required }) => {
+    const fieldError = identityErrors[field];
+
+    return (
+      <div key={field} className="mb-4">
+        <label
+          htmlFor={`${identityKey}-${field}`}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {BUILTIN_LABELS[field] || field}
+          {required && <span className="text-red-500 ml-1">*</span>}
+        </label>
+        <input
+          id={`${identityKey}-${field}`}
+          type={field === 'email' ? 'email' : field === 'phone' ? 'tel' : 'text'}
+          value={identityValues[field] ?? ''}
+          placeholder={BUILTIN_LABELS[field]}
+          className={readOnly ? readOnlyInputClass : interactiveInputClass(fieldError)}
+          disabled={readOnly}
+          readOnly={readOnly}
+          onChange={readOnly ? undefined : e => onIdentityFieldChange?.(field, e.target.value)}
+          aria-invalid={Boolean(fieldError)}
+          aria-describedby={fieldError ? `${identityKey}-${field}-error` : undefined}
+        />
+        {fieldError && (
+          <p id={`${identityKey}-${field}-error`} className="mt-1 text-xs text-red-600">
+            {fieldError}
+          </p>
+        )}
+      </div>
+    );
+  };
 
   const renderCustomQuestion = question => {
     const { id, label, type, required, options = [] } = question;
     const answer = customAnswers[id];
+    const fieldError = customErrors[id];
+    const inputClass = readOnly ? readOnlyInputClass : interactiveInputClass(fieldError);
 
     switch (type) {
       case FORM_QUESTION_TYPE.TEXTAREA:
         return (
           <div key={id} className="mb-4">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor={`question-${id}`}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               {label}
               {required && <span className="text-red-500 ml-1">*</span>}
             </label>
             <textarea
+              id={`question-${id}`}
               value={typeof answer === 'string' ? answer : ''}
               rows={3}
               className={inputClass}
-              {...disabledProps}
+              disabled={readOnly}
+              readOnly={readOnly}
+              onChange={readOnly ? undefined : e => onCustomAnswerChange?.(id, e.target.value)}
+              aria-invalid={Boolean(fieldError)}
+              aria-describedby={fieldError ? `question-${id}-error` : undefined}
             />
+            {fieldError && (
+              <p id={`question-${id}-error`} className="mt-1 text-xs text-red-600">
+                {fieldError}
+              </p>
+            )}
           </div>
         );
 
       case FORM_QUESTION_TYPE.SELECT:
         return (
           <div key={id} className="mb-4">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor={`question-${id}`}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               {label}
               {required && <span className="text-red-500 ml-1">*</span>}
             </label>
             <select
+              id={`question-${id}`}
               value={typeof answer === 'string' ? answer : ''}
               className={inputClass}
-              {...disabledProps}
+              disabled={readOnly}
+              onChange={readOnly ? undefined : e => onCustomAnswerChange?.(id, e.target.value)}
+              aria-invalid={Boolean(fieldError)}
+              aria-describedby={fieldError ? `question-${id}-error` : undefined}
             >
               <option value="">Select an option</option>
               {options.map(opt => (
@@ -90,22 +138,38 @@ const DynamicEventForm = ({
                 </option>
               ))}
             </select>
+            {fieldError && (
+              <p id={`question-${id}-error`} className="mt-1 text-xs text-red-600">
+                {fieldError}
+              </p>
+            )}
           </div>
         );
 
       case FORM_QUESTION_TYPE.CHECKBOX:
         return (
-          <div key={id} className="mb-4 flex items-start gap-2">
-            <input
-              type="checkbox"
-              checked={Boolean(answer)}
-              className="mt-1 h-4 w-4 rounded border-gray-300"
-              {...disabledProps}
-            />
-            <label className="text-sm text-gray-700">
-              {label}
-              {required && <span className="text-red-500 ml-1">*</span>}
-            </label>
+          <div key={id} className="mb-4">
+            <div className="flex items-start gap-2">
+              <input
+                id={`question-${id}`}
+                type="checkbox"
+                checked={Boolean(answer)}
+                className="mt-1 h-4 w-4 rounded border-gray-300"
+                disabled={readOnly}
+                onChange={readOnly ? undefined : e => onCustomAnswerChange?.(id, e.target.checked)}
+                aria-invalid={Boolean(fieldError)}
+                aria-describedby={fieldError ? `question-${id}-error` : undefined}
+              />
+              <label htmlFor={`question-${id}`} className="text-sm text-gray-700">
+                {label}
+                {required && <span className="text-red-500 ml-1">*</span>}
+              </label>
+            </div>
+            {fieldError && (
+              <p id={`question-${id}-error`} className="mt-1 text-xs text-red-600">
+                {fieldError}
+              </p>
+            )}
           </div>
         );
 
@@ -113,16 +177,29 @@ const DynamicEventForm = ({
       default:
         return (
           <div key={id} className="mb-4">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor={`question-${id}`}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               {label}
               {required && <span className="text-red-500 ml-1">*</span>}
             </label>
             <input
+              id={`question-${id}`}
               type="text"
               value={typeof answer === 'string' ? answer : ''}
               className={inputClass}
-              {...disabledProps}
+              disabled={readOnly}
+              readOnly={readOnly}
+              onChange={readOnly ? undefined : e => onCustomAnswerChange?.(id, e.target.value)}
+              aria-invalid={Boolean(fieldError)}
+              aria-describedby={fieldError ? `question-${id}-error` : undefined}
             />
+            {fieldError && (
+              <p id={`question-${id}-error`} className="mt-1 text-xs text-red-600">
+                {fieldError}
+              </p>
+            )}
           </div>
         );
     }

--- a/src/components/events/EventRegistrationPanel.jsx
+++ b/src/components/events/EventRegistrationPanel.jsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from 'react';
+
+import { createGuestSession } from '../../api/auth';
+import { useAuthState } from '../../contexts/auth/useAuth';
+import { useRegisterForEvent } from '../../hooks/mutations/useEventMutations';
+import { validateEventForm } from '../../utils/events/validateEventForm';
+import Button from '../ui/Button';
+import DynamicEventForm from './DynamicEventForm';
+
+const buildInitialGuestInfo = (formSchema, currentUser) => {
+  const guestInfo = {};
+  const fields = formSchema?.builtinFields || [];
+
+  for (const { field } of fields) {
+    if (field === 'name') {
+      guestInfo.name = currentUser?.displayName || currentUser?.name || '';
+    } else if (field === 'email') {
+      guestInfo.email = currentUser?.email || '';
+    } else if (field === 'phone') {
+      guestInfo.phone = currentUser?.contact || currentUser?.phoneNumber || '';
+    }
+  }
+
+  return guestInfo;
+};
+
+const getRegistrationErrorMessage = error => {
+  const apiMessage = error?.response?.data?.error || error?.response?.data?.message;
+  if (apiMessage) return apiMessage;
+  return error?.message || 'Failed to register for this event. Please try again.';
+};
+
+/**
+ * Free event RSVP panel — guest session, form validation, and registration submit.
+ *
+ * @param {Object} props
+ * @param {Object} props.event - Published event from GET /events/:slug
+ * @param {(registration: Object, payload: Object) => void} [props.onSuccess]
+ */
+const EventRegistrationPanel = ({ event, onSuccess }) => {
+  const { currentUser, isAuthenticated } = useAuthState();
+  const registerMutation = useRegisterForEvent();
+
+  const registrationForm = event.registrationForm;
+  const isFull = event.spotsRemaining === 0;
+
+  const [values, setValues] = useState(() => ({
+    guestInfo: buildInitialGuestInfo(registrationForm, currentUser),
+    formResponses: { customAnswers: {} },
+  }));
+  const [errors, setErrors] = useState({ identity: {}, customAnswers: {} });
+  const [submitError, setSubmitError] = useState('');
+
+  const resolvedEmail = useMemo(
+    () => (isAuthenticated ? currentUser?.email : undefined),
+    [isAuthenticated, currentUser?.email]
+  );
+
+  const clearIdentityError = field => {
+    setErrors(prev => {
+      if (!prev.identity?.[field]) return prev;
+      const { [field]: _, ...rest } = prev.identity;
+      return { ...prev, identity: rest };
+    });
+  };
+
+  const clearCustomError = questionId => {
+    setErrors(prev => {
+      if (!prev.customAnswers?.[questionId]) return prev;
+      const { [questionId]: _, ...rest } = prev.customAnswers;
+      return { ...prev, customAnswers: rest };
+    });
+  };
+
+  const handleIdentityFieldChange = (field, value) => {
+    setValues(prev => ({
+      ...prev,
+      guestInfo: { ...prev.guestInfo, [field]: value },
+    }));
+    clearIdentityError(field);
+    if (submitError) setSubmitError('');
+  };
+
+  const handleCustomAnswerChange = (questionId, value) => {
+    setValues(prev => ({
+      ...prev,
+      formResponses: {
+        customAnswers: {
+          ...prev.formResponses.customAnswers,
+          [questionId]: value,
+        },
+      },
+    }));
+    clearCustomError(questionId);
+    if (submitError) setSubmitError('');
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setSubmitError('');
+
+    const validation = validateEventForm(registrationForm, {
+      identity: values.guestInfo,
+      customAnswers: values.formResponses.customAnswers,
+      resolvedEmail,
+    });
+
+    if (!validation.isValid) {
+      setErrors(validation.errors);
+      return;
+    }
+
+    const payload = {
+      guestInfo: validation.normalized.identity,
+      formResponses: { customAnswers: validation.normalized.customAnswers },
+    };
+
+    try {
+      if (!isAuthenticated) {
+        await createGuestSession();
+      }
+
+      const response = await registerMutation.mutateAsync({
+        slug: event.slug,
+        body: payload,
+      });
+
+      onSuccess?.(response.data, payload);
+    } catch (error) {
+      setSubmitError(getRegistrationErrorMessage(error));
+    }
+  };
+
+  if (!registrationForm) {
+    return (
+      <section className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">Registration</h2>
+        <p className="text-sm text-gray-500">Registration is not available for this event yet.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-2">Registration</h2>
+      <p className="text-sm text-gray-600 mb-4">
+        Reserve your spot for this free event. Fill in the details below to register.
+      </p>
+
+      {isFull ? (
+        <p className="text-sm font-medium text-red-600">This event is full — no spots remaining.</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          <DynamicEventForm
+            formSchema={registrationForm}
+            identityKey="guestInfo"
+            values={values}
+            errors={errors}
+            readOnly={false}
+            onIdentityFieldChange={handleIdentityFieldChange}
+            onCustomAnswerChange={handleCustomAnswerChange}
+          />
+
+          {submitError && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {submitError}
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-full px-4 py-3 text-sm"
+            disabled={registerMutation.isPending}
+          >
+            {registerMutation.isPending ? 'Registering…' : 'Register for event'}
+          </Button>
+        </form>
+      )}
+    </section>
+  );
+};
+
+export default EventRegistrationPanel;

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo } from 'react';
-import { Link, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 import { Calendar, MapPin, Users } from 'lucide-react';
 
 import SEO from '../components/SEO';
 import Button from '../components/ui/Button';
+import EventRegistrationPanel from '../components/events/EventRegistrationPanel';
 import NotFound from '../components/ui/NotFound';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { useEvent } from '../hooks/queries/useEvents';
@@ -25,6 +26,7 @@ const getSpotsLabel = spotsRemaining => {
 
 const EventDetails = () => {
   const { slug } = useParams();
+  const navigate = useNavigate();
   const { data, isLoading, isError, error } = useEvent(slug);
 
   const event = data?.data || null;
@@ -170,15 +172,26 @@ const EventDetails = () => {
 
           <aside className="space-y-6">
             {isFree && (
-              <section className="bg-white rounded-lg border border-gray-200 p-6">
-                <h2 className="text-lg font-semibold text-gray-900 mb-2">Registration</h2>
-                <p className="text-sm text-gray-600 mb-4">
-                  Reserve your spot for this free event. Online registration opens soon.
-                </p>
-                <Button variant="primary" className="w-full px-4 py-3 text-sm" disabled>
-                  Coming soon
-                </Button>
-              </section>
+              <EventRegistrationPanel
+                event={event}
+                onSuccess={(registration, payload) => {
+                  navigate(`/events/${event.slug}/confirmation`, {
+                    state: {
+                      registrationSummary: {
+                        type: 'free',
+                        event: {
+                          name: event.name,
+                          slug: event.slug,
+                          eventDate: event.eventDate,
+                          venue: event.venue,
+                        },
+                        guestInfo: payload.guestInfo,
+                        registration,
+                      },
+                    },
+                  });
+                }}
+              />
             )}
 
             {isPaid && (

--- a/src/utils/events/index.js
+++ b/src/utils/events/index.js
@@ -6,3 +6,4 @@ export {
   getRegistrationStatusColor,
   getVolunteerStatusColor,
 } from './statusBadges';
+export { validateEventForm } from './validateEventForm';

--- a/src/utils/events/validateEventForm.js
+++ b/src/utils/events/validateEventForm.js
@@ -1,0 +1,185 @@
+import { FORM_QUESTION_TYPE } from '../../constants/events';
+import { isValidEmail } from '../validation';
+
+const BUILTIN_LABELS = {
+  name: 'Full name',
+  email: 'Email',
+  phone: 'Phone',
+};
+
+const isMissing = value => value === undefined || value === null || value === '';
+
+const normalizeString = value => (typeof value === 'string' ? value.trim() : value);
+
+const validateBuiltinField = (field, value, required) => {
+  if (required && isMissing(value)) {
+    return `${BUILTIN_LABELS[field] || field} is required`;
+  }
+
+  if (isMissing(value)) {
+    return null;
+  }
+
+  const normalized = normalizeString(value);
+
+  if (field === 'email' && !isValidEmail(normalized)) {
+    return 'Please enter a valid email address';
+  }
+
+  if (field === 'name' && normalized.length === 0) {
+    return `${BUILTIN_LABELS.name} is required`;
+  }
+
+  if (field === 'phone' && normalized.length === 0) {
+    return `${BUILTIN_LABELS.phone} is required`;
+  }
+
+  return null;
+};
+
+const validateCustomAnswer = (question, value) => {
+  const { label, type, required, options = [] } = question;
+
+  if (required && isMissing(value)) {
+    return `${label} is required`;
+  }
+
+  if (isMissing(value)) {
+    return null;
+  }
+
+  if (type === FORM_QUESTION_TYPE.TEXT || type === FORM_QUESTION_TYPE.TEXTAREA) {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      return `${label} must be answered with text`;
+    }
+    return null;
+  }
+
+  if (type === FORM_QUESTION_TYPE.SELECT) {
+    const normalized = normalizeString(value);
+    if (!options.includes(normalized)) {
+      return `${label} must match one of the configured options`;
+    }
+    return null;
+  }
+
+  if (type === FORM_QUESTION_TYPE.CHECKBOX) {
+    if (typeof value !== 'boolean') {
+      return `${label} must be answered with true or false`;
+    }
+    return null;
+  }
+
+  return `${label} has an unsupported question type`;
+};
+
+const normalizeIdentity = (schemaFields, identity = {}, resolvedEmail) => {
+  const normalized = {};
+
+  for (const { field, required } of schemaFields) {
+    let value = field === 'email' && resolvedEmail ? resolvedEmail : identity[field];
+
+    if (isMissing(value)) {
+      if (!required) continue;
+      value = field === 'email' ? resolvedEmail : value;
+    }
+
+    if (isMissing(value)) continue;
+
+    normalized[field] = normalizeString(value);
+  }
+
+  return normalized;
+};
+
+const normalizeCustomAnswers = (questions, answers = {}) => {
+  const normalized = {};
+
+  for (const question of questions) {
+    const value = answers[question.id];
+    if (isMissing(value)) continue;
+
+    if (question.type === FORM_QUESTION_TYPE.CHECKBOX) {
+      normalized[question.id] = Boolean(value);
+    } else if (
+      question.type === FORM_QUESTION_TYPE.TEXT ||
+      question.type === FORM_QUESTION_TYPE.TEXTAREA
+    ) {
+      normalized[question.id] = value.trim();
+    } else {
+      normalized[question.id] = normalizeString(value);
+    }
+  }
+
+  return normalized;
+};
+
+/**
+ * Validates event registration/volunteer form values before submit.
+ * Mirrors backend formValidationLogic rules with field-keyed errors for inline UI.
+ *
+ * @param {Object} formSchema - { builtinFields, customQuestions }
+ * @param {Object} options
+ * @param {Object} options.identity - guestInfo or applicantInfo values
+ * @param {Object} options.customAnswers - custom question answers keyed by question id
+ * @param {string} [options.resolvedEmail] - account email when authenticated
+ * @returns {{ isValid: boolean, errors: { identity: Object, customAnswers: Object }, normalized: { identity: Object, customAnswers: Object } }}
+ */
+export const validateEventForm = (
+  formSchema,
+  { identity = {}, customAnswers = {}, resolvedEmail } = {}
+) => {
+  const errors = { identity: {}, customAnswers: {} };
+
+  if (!formSchema) {
+    return {
+      isValid: true,
+      errors,
+      normalized: { identity: {}, customAnswers: {} },
+    };
+  }
+
+  const { builtinFields = [], customQuestions = [] } = formSchema;
+  const identityInput = { ...identity };
+
+  if (resolvedEmail && isMissing(identityInput.email)) {
+    identityInput.email = resolvedEmail;
+  }
+
+  for (const { field, required } of builtinFields) {
+    const value = field === 'email' ? identityInput.email : identityInput[field];
+    const message = validateBuiltinField(field, value, required);
+    if (message) {
+      errors.identity[field] = message;
+    }
+  }
+
+  if (!resolvedEmail && !identityInput.email) {
+    if (!errors.identity.email && builtinFields.some(f => f.field === 'email' && f.required)) {
+      errors.identity.email = `${BUILTIN_LABELS.email} is required`;
+    }
+  } else if (!resolvedEmail && identityInput.email && !errors.identity.email) {
+    if (!isValidEmail(normalizeString(identityInput.email))) {
+      errors.identity.email = 'Please enter a valid email address';
+    }
+  }
+
+  for (const question of customQuestions) {
+    const message = validateCustomAnswer(question, customAnswers[question.id]);
+    if (message) {
+      errors.customAnswers[question.id] = message;
+    }
+  }
+
+  const hasErrors =
+    Object.keys(errors.identity).length > 0 || Object.keys(errors.customAnswers).length > 0;
+
+  return {
+    isValid: !hasErrors,
+    errors,
+    normalized: {
+      identity: normalizeIdentity(builtinFields, identityInput, resolvedEmail),
+      customAnswers: normalizeCustomAnswers(customQuestions, customAnswers),
+    },
+  };
+};

--- a/tests/validateEventForm.test.js
+++ b/tests/validateEventForm.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+
+import { FORM_QUESTION_TYPE } from '../src/constants/events';
+import { validateEventForm } from '../src/utils/events/validateEventForm';
+
+const baseSchema = {
+  builtinFields: [
+    { field: 'name', required: true },
+    { field: 'email', required: true },
+  ],
+  customQuestions: [
+    {
+      id: 'diet',
+      label: 'Dietary requirements',
+      type: FORM_QUESTION_TYPE.TEXT,
+      required: false,
+    },
+    {
+      id: 'terms',
+      label: 'Accept terms',
+      type: FORM_QUESTION_TYPE.CHECKBOX,
+      required: true,
+    },
+  ],
+};
+
+describe('validateEventForm', () => {
+  test('returns valid for complete identity and custom answers', () => {
+    const result = validateEventForm(baseSchema, {
+      identity: { name: 'Ama Mensah', email: 'ama@example.com' },
+      customAnswers: { terms: true },
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.normalized.identity).toEqual({
+      name: 'Ama Mensah',
+      email: 'ama@example.com',
+    });
+    expect(result.normalized.customAnswers).toEqual({ terms: true });
+  });
+
+  test('flags missing required builtin fields', () => {
+    const result = validateEventForm(baseSchema, {
+      identity: { name: '', email: '' },
+      customAnswers: {},
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.identity.name).toBe('Full name is required');
+    expect(result.errors.identity.email).toBe('Email is required');
+  });
+
+  test('uses resolvedEmail for authenticated users without email field value', () => {
+    const result = validateEventForm(baseSchema, {
+      identity: { name: 'Ama Mensah' },
+      customAnswers: { terms: true },
+      resolvedEmail: 'ama@example.com',
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.normalized.identity.email).toBe('ama@example.com');
+  });
+
+  test('validates select options and required custom questions', () => {
+    const schema = {
+      builtinFields: [{ field: 'email', required: true }],
+      customQuestions: [
+        {
+          id: 'size',
+          label: 'T-shirt size',
+          type: FORM_QUESTION_TYPE.SELECT,
+          required: true,
+          options: ['S', 'M', 'L'],
+        },
+      ],
+    };
+
+    const invalid = validateEventForm(schema, {
+      identity: { email: 'ama@example.com' },
+      customAnswers: { size: 'XL' },
+    });
+    expect(invalid.isValid).toBe(false);
+    expect(invalid.errors.customAnswers.size).toContain('configured options');
+
+    const missing = validateEventForm(schema, {
+      identity: { email: 'ama@example.com' },
+      customAnswers: {},
+    });
+    expect(missing.isValid).toBe(false);
+    expect(missing.errors.customAnswers.size).toBe('T-shirt size is required');
+  });
+});


### PR DESCRIPTION
Add free event RSVP on the public event detail page so visitors can register with the configured registration form. Successful submissions redirect to the confirmation path with registration state for Branch 10.

- Add interactive validation to DynamicEventForm for builtin and custom questions
- Add EventRegistrationPanel with guest session, auth prefill, and error handling
- Wire free registration on EventDetails and redirect to confirmation with state
