### PR TITLE
Add paid event checkout and confirmation flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ const AuthCallback = lazy(() => import('./pages/auth/AuthCallback'));
 const Bespoke = lazy(() => import('./pages/Bespoke'));
 const Events = lazy(() => import('./pages/Events'));
 const EventDetails = lazy(() => import('./pages/EventDetails'));
+const EventConfirmation = lazy(() => import('./pages/EventConfirmation'));
 const CategoryPage = lazy(() => import('./pages/CategoryPage'));
 const ProductDetails = lazy(() => import('./pages/ProductDetails'));
 const Orders = lazy(() => import('./pages/Orders'));
@@ -117,6 +118,16 @@ const App = () => {
             <MainLayout>
               <Suspense fallback={<PageLoader />}>
                 <Events />
+              </Suspense>
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/events/:slug/confirmation"
+          element={
+            <MainLayout>
+              <Suspense fallback={<PageLoader />}>
+                <EventConfirmation />
               </Suspense>
             </MainLayout>
           }

--- a/src/components/events/EventTicketCheckout.jsx
+++ b/src/components/events/EventTicketCheckout.jsx
@@ -1,0 +1,321 @@
+import { useMemo, useState } from 'react';
+
+import { createGuestSession } from '../../api/auth';
+import { useAuthState } from '../../contexts/auth/useAuth';
+import { useCheckoutEvent } from '../../hooks/mutations/useEventMutations';
+import { formatCurrency } from '../../utils/admin/tableHelpers';
+import { pesewasToGhs, validateEventForm } from '../../utils/events';
+import Button from '../ui/Button';
+import DynamicEventForm from './DynamicEventForm';
+
+const EVENT_CHECKOUT_SLUG_KEY = 'misqabbi_event_checkout_slug';
+
+const buildInitialGuestInfo = (formSchema, currentUser) => {
+  const guestInfo = {};
+  const fields = formSchema?.builtinFields || [];
+
+  for (const { field } of fields) {
+    if (field === 'name') {
+      guestInfo.name = currentUser?.displayName || currentUser?.name || '';
+    } else if (field === 'email') {
+      guestInfo.email = currentUser?.email || '';
+    } else if (field === 'phone') {
+      guestInfo.phone = currentUser?.contact || currentUser?.phoneNumber || '';
+    }
+  }
+
+  return guestInfo;
+};
+
+const getCheckoutErrorMessage = error => {
+  const apiMessage = error?.response?.data?.error || error?.response?.data?.message;
+  if (apiMessage) return apiMessage;
+  return error?.message || 'Failed to start checkout. Please try again.';
+};
+
+/**
+ * Paid event ticket checkout — ticket selection, registration form, and Paystack redirect.
+ *
+ * @param {Object} props
+ * @param {Object} props.event - Published paid event from GET /events/:slug
+ */
+const EventTicketCheckout = ({ event }) => {
+  const { currentUser, isAuthenticated } = useAuthState();
+  const checkoutMutation = useCheckoutEvent();
+
+  const registrationForm = event.registrationForm;
+  const activeTickets = useMemo(
+    () => (event.ticketTypes || []).filter(t => t.isActive),
+    [event.ticketTypes]
+  );
+
+  const defaultTicketId = useMemo(() => {
+    const available = activeTickets.find(t => (t.remainingQuantity ?? 0) > 0);
+    return available?._id || activeTickets[0]?._id || '';
+  }, [activeTickets]);
+
+  const [selectedTicketId, setSelectedTicketId] = useState(defaultTicketId);
+  const [quantity, setQuantity] = useState(1);
+  const [values, setValues] = useState(() => ({
+    guestInfo: buildInitialGuestInfo(registrationForm, currentUser),
+    formResponses: { customAnswers: {} },
+  }));
+  const [errors, setErrors] = useState({ identity: {}, customAnswers: {} });
+  const [submitError, setSubmitError] = useState('');
+
+  const selectedTicket = activeTickets.find(t => t._id === selectedTicketId) || null;
+  const eventFull = event.spotsRemaining === 0;
+  const ticketSoldOut = selectedTicket ? (selectedTicket.remainingQuantity ?? 0) === 0 : true;
+  const maxQuantity = selectedTicket
+    ? Math.max(1, Math.min(selectedTicket.remainingQuantity ?? 1, event.spotsRemaining ?? 99))
+    : 1;
+
+  const lineTotalPesewas = selectedTicket ? Number(selectedTicket.pricePesewas) * quantity : 0;
+
+  const resolvedEmail = useMemo(
+    () => (isAuthenticated ? currentUser?.email : undefined),
+    [isAuthenticated, currentUser?.email]
+  );
+
+  const clearIdentityError = field => {
+    setErrors(prev => {
+      if (!prev.identity?.[field]) return prev;
+      const { [field]: _, ...rest } = prev.identity;
+      return { ...prev, identity: rest };
+    });
+  };
+
+  const clearCustomError = questionId => {
+    setErrors(prev => {
+      if (!prev.customAnswers?.[questionId]) return prev;
+      const { [questionId]: _, ...rest } = prev.customAnswers;
+      return { ...prev, customAnswers: rest };
+    });
+  };
+
+  const handleIdentityFieldChange = (field, value) => {
+    setValues(prev => ({
+      ...prev,
+      guestInfo: { ...prev.guestInfo, [field]: value },
+    }));
+    clearIdentityError(field);
+    if (submitError) setSubmitError('');
+  };
+
+  const handleCustomAnswerChange = (questionId, value) => {
+    setValues(prev => ({
+      ...prev,
+      formResponses: {
+        customAnswers: {
+          ...prev.formResponses.customAnswers,
+          [questionId]: value,
+        },
+      },
+    }));
+    clearCustomError(questionId);
+    if (submitError) setSubmitError('');
+  };
+
+  const handleTicketChange = ticketId => {
+    setSelectedTicketId(ticketId);
+    setQuantity(1);
+    if (submitError) setSubmitError('');
+  };
+
+  const handleQuantityChange = e => {
+    const next = Math.max(1, parseInt(e.target.value, 10) || 1);
+    setQuantity(Math.min(next, maxQuantity));
+    if (submitError) setSubmitError('');
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setSubmitError('');
+
+    if (!selectedTicket || ticketSoldOut || eventFull) return;
+
+    const validation = validateEventForm(registrationForm, {
+      identity: values.guestInfo,
+      customAnswers: values.formResponses.customAnswers,
+      resolvedEmail,
+    });
+
+    if (!validation.isValid) {
+      setErrors(validation.errors);
+      return;
+    }
+
+    const payload = {
+      ticketTypeId: selectedTicket._id,
+      quantity,
+      guestInfo: validation.normalized.identity,
+      formResponses: { customAnswers: validation.normalized.customAnswers },
+    };
+
+    try {
+      if (!isAuthenticated) {
+        await createGuestSession();
+      }
+
+      const response = await checkoutMutation.mutateAsync({
+        slug: event.slug,
+        body: payload,
+      });
+
+      sessionStorage.setItem(EVENT_CHECKOUT_SLUG_KEY, event.slug);
+      window.location.href = response.data.authorizationUrl;
+    } catch (error) {
+      setSubmitError(getCheckoutErrorMessage(error));
+    }
+  };
+
+  if (activeTickets.length === 0) {
+    return (
+      <section className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">Tickets</h2>
+        <p className="text-sm text-gray-500">Tickets are not available yet.</p>
+      </section>
+    );
+  }
+
+  if (!registrationForm) {
+    return (
+      <section className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">Tickets</h2>
+        <p className="text-sm text-gray-500">Registration is not available for this event yet.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-2">Get tickets</h2>
+      <p className="text-sm text-gray-600 mb-4">
+        Select a ticket type and complete the registration form to proceed to payment.
+      </p>
+
+      {eventFull ? (
+        <p className="text-sm font-medium text-red-600">This event is full — no spots remaining.</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+          <div>
+            <p className="text-sm font-medium text-gray-900 mb-2">Ticket type</p>
+            <ul className="space-y-2">
+              {activeTickets.map(ticket => {
+                const soldOut = (ticket.remainingQuantity ?? 0) === 0;
+                const isSelected = ticket._id === selectedTicketId;
+                return (
+                  <li key={ticket._id}>
+                    <label
+                      className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer ${
+                        soldOut
+                          ? 'border-gray-200 bg-gray-50 opacity-75 cursor-not-allowed'
+                          : isSelected
+                            ? 'border-msq-purple-rich ring-1 ring-msq-purple-rich/30'
+                            : 'border-gray-200 hover:border-gray-300'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="ticketType"
+                        value={ticket._id}
+                        checked={isSelected}
+                        disabled={soldOut}
+                        onChange={() => handleTicketChange(ticket._id)}
+                        className="mt-1"
+                      />
+                      <span className="flex-1 min-w-0">
+                        <span className="flex items-center justify-between gap-2">
+                          <span className="font-medium text-gray-900">{ticket.name}</span>
+                          <span className="text-sm text-gray-700 shrink-0">
+                            {formatCurrency(pesewasToGhs(ticket.pricePesewas))}
+                          </span>
+                        </span>
+                        {soldOut ? (
+                          <span className="inline-block mt-1 text-xs font-medium text-gray-500">
+                            Sold out
+                          </span>
+                        ) : (
+                          <span className="block mt-1 text-xs text-gray-500">
+                            {ticket.remainingQuantity} available
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          {selectedTicket && !ticketSoldOut && (
+            <>
+              <div>
+                <label
+                  htmlFor="ticket-quantity"
+                  className="block text-sm font-medium text-gray-900 mb-1"
+                >
+                  Quantity
+                </label>
+                <input
+                  id="ticket-quantity"
+                  type="number"
+                  min={1}
+                  max={maxQuantity}
+                  value={quantity}
+                  onChange={handleQuantityChange}
+                  className="w-24 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-msq-purple-rich/30"
+                />
+              </div>
+
+              <div className="rounded-md bg-gray-50 border border-gray-200 px-3 py-2 text-sm">
+                <span className="text-gray-600">Total: </span>
+                <span className="font-semibold text-gray-900">
+                  {formatCurrency(pesewasToGhs(lineTotalPesewas))}
+                </span>
+              </div>
+
+              <DynamicEventForm
+                formSchema={registrationForm}
+                identityKey="guestInfo"
+                values={values}
+                errors={errors}
+                readOnly={false}
+                onIdentityFieldChange={handleIdentityFieldChange}
+                onCustomAnswerChange={handleCustomAnswerChange}
+              />
+
+              <p className="text-xs text-gray-500">
+                Spots may change while you complete checkout. If capacity runs out, payment will not
+                be completed.
+              </p>
+
+              {submitError && (
+                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  {submitError}
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                variant="primary"
+                className="w-full px-4 py-3 text-sm"
+                disabled={checkoutMutation.isPending || ticketSoldOut || eventFull}
+              >
+                {checkoutMutation.isPending ? 'Redirecting to payment…' : 'Continue to payment'}
+              </Button>
+            </>
+          )}
+
+          {selectedTicket && ticketSoldOut && !eventFull && (
+            <p className="text-sm font-medium text-red-600">
+              The selected ticket type is sold out. Choose another ticket type.
+            </p>
+          )}
+        </form>
+      )}
+    </section>
+  );
+};
+
+export default EventTicketCheckout;

--- a/src/pages/EventConfirmation.jsx
+++ b/src/pages/EventConfirmation.jsx
@@ -1,0 +1,296 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router';
+import { Calendar, CheckCircle2, MapPin, XCircle } from 'lucide-react';
+
+import SEO from '../components/SEO';
+import Button from '../components/ui/Button';
+import { LoadingSpinner } from '../components/ui/LoadingSpinner';
+import NotFound from '../components/ui/NotFound';
+import { verifyPayment } from '../api/payments';
+import { useEvent } from '../hooks/queries/useEvents';
+import { formatCurrency } from '../utils/admin/tableHelpers';
+import { formatEventDate, formatEventVenue, pesewasToGhs } from '../utils/events';
+
+const isSuccessfulTransaction = transaction =>
+  transaction?.status === 'success' || transaction?.status === 'paid';
+
+const isFailedTransaction = transaction =>
+  transaction?.status === 'failed' || transaction?.status === 'abandoned';
+
+/**
+ * Event registration confirmation — paid (verify by reference) or free (location.state from RSVP).
+ */
+const EventConfirmation = () => {
+  const { slug } = useParams();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  const freeSummary = location.state?.registrationSummary;
+  const reference = searchParams.get('reference');
+  const isPaidFlow = Boolean(reference);
+
+  const { data: eventData } = useEvent(slug, {
+    enabled: isPaidFlow && Boolean(slug),
+  });
+  const eventFromQuery = eventData?.data || null;
+
+  const [paidState, setPaidState] = useState({
+    loading: isPaidFlow,
+    error: '',
+    transaction: null,
+    registration: null,
+  });
+
+  useEffect(() => {
+    if (!isPaidFlow || !reference) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await verifyPayment(reference);
+        if (cancelled) return;
+
+        const transaction = res?.data?.transaction;
+        const registration = res?.data?.eventRegistration;
+
+        if (!transaction || transaction.purpose !== 'event_ticket') {
+          setPaidState({
+            loading: false,
+            error: 'This payment reference is not for an event ticket.',
+            transaction: null,
+            registration: null,
+          });
+          return;
+        }
+
+        if (isFailedTransaction(transaction)) {
+          setPaidState({
+            loading: false,
+            error: 'Payment was not completed. Your registration was not confirmed.',
+            transaction,
+            registration: null,
+          });
+          return;
+        }
+
+        if (!isSuccessfulTransaction(transaction) || !registration) {
+          setPaidState({
+            loading: false,
+            error: 'Payment is still being processed. Please refresh in a moment.',
+            transaction,
+            registration: null,
+          });
+          return;
+        }
+
+        setPaidState({
+          loading: false,
+          error: '',
+          transaction,
+          registration,
+        });
+      } catch (error) {
+        if (cancelled) return;
+        setPaidState({
+          loading: false,
+          error: error?.message || 'Failed to verify payment.',
+          transaction: null,
+          registration: null,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isPaidFlow, reference]);
+
+  const freeEvent = freeSummary?.type === 'free' ? freeSummary.event : null;
+
+  const paidEvent = useMemo(() => {
+    if (!paidState.registration && !eventFromQuery) return null;
+    if (eventFromQuery) {
+      return {
+        name: eventFromQuery.name,
+        slug: eventFromQuery.slug,
+        eventDate: eventFromQuery.eventDate,
+        venue: eventFromQuery.venue,
+      };
+    }
+    return slug ? { name: slug, slug, eventDate: null, venue: null } : null;
+  }, [eventFromQuery, paidState.registration, slug]);
+
+  const paidTicketLabel = useMemo(() => {
+    const purchase = paidState.transaction?.eventPurchaseData;
+    if (!purchase?.ticketName) return null;
+    const qty = purchase.quantity || 1;
+    const unitPrice = purchase.pricePerTicket
+      ? formatCurrency(pesewasToGhs(purchase.pricePerTicket))
+      : null;
+    return `${purchase.ticketName}${qty > 1 ? ` × ${qty}` : ''}${unitPrice ? ` — ${unitPrice} each` : ''}`;
+  }, [paidState.transaction]);
+
+  if (!isPaidFlow && !freeSummary) {
+    return (
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-8">
+        <SEO title="Registration confirmation" robots="noindex,nofollow" />
+        <div className="max-w-lg mx-auto text-center space-y-4">
+          <XCircle className="w-12 h-12 text-gray-400 mx-auto" aria-hidden="true" />
+          <h1 className="text-xl font-semibold text-gray-900">No registration found</h1>
+          <p className="text-sm text-gray-600">
+            This page is shown after a successful registration. If you just paid for tickets, use
+            the link from your payment confirmation.
+          </p>
+          <Link to="/events">
+            <Button variant="primary" className="px-6 py-2 text-sm">
+              Browse events
+            </Button>
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  if (isPaidFlow && paidState.loading) {
+    return (
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-16 flex justify-center">
+        <SEO title="Confirming registration" robots="noindex,nofollow" />
+        <LoadingSpinner size={48} />
+      </main>
+    );
+  }
+
+  if (isPaidFlow && paidState.error) {
+    return (
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-8">
+        <SEO title="Registration not confirmed" robots="noindex,nofollow" />
+        <div className="max-w-lg mx-auto space-y-4">
+          <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+            <XCircle className="w-10 h-10 text-red-500 mx-auto mb-3" aria-hidden="true" />
+            <h1 className="text-lg font-semibold text-red-800 mb-2">Registration not confirmed</h1>
+            <p className="text-sm text-red-700">{paidState.error}</p>
+            {reference && (
+              <p className="text-xs text-red-600 mt-2 font-mono">Reference: {reference}</p>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-3 justify-center">
+            {slug && (
+              <Link to={`/events/${slug}`}>
+                <Button variant="primary" className="px-4 py-2 text-sm">
+                  Back to event
+                </Button>
+              </Link>
+            )}
+            <Link to="/events">
+              <Button variant="ghost" className="px-4 py-2 text-sm">
+                All events
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const displayEvent = isPaidFlow ? paidEvent : freeEvent;
+  const guestInfo = isPaidFlow ? paidState.registration?.guestInfo : freeSummary?.guestInfo;
+
+  if (isPaidFlow && !displayEvent) {
+    return <NotFound />;
+  }
+
+  const eventTitle = displayEvent?.name || 'Event';
+  const venueLabel = formatEventVenue(displayEvent?.venue);
+
+  return (
+    <main className="w-full px-4 sm:px-6 lg:px-8 py-8">
+      <SEO
+        title={`Registration confirmed — ${eventTitle}`}
+        description={`Your registration for ${eventTitle} is confirmed.`}
+        robots="noindex,nofollow"
+        canonicalPath={displayEvent?.slug ? `/events/${displayEvent.slug}/confirmation` : undefined}
+      />
+
+      <div className="max-w-lg mx-auto">
+        <div className="rounded-lg border border-green-200 bg-green-50 p-6 mb-6">
+          <div className="flex items-start gap-3">
+            <CheckCircle2 className="w-8 h-8 text-green-600 shrink-0" aria-hidden="true" />
+            <div>
+              <h1 className="text-xl font-semibold text-green-900 mb-1">You&apos;re registered!</h1>
+              <p className="text-sm text-green-800">
+                {isPaidFlow
+                  ? 'Your payment was successful and your ticket registration is confirmed.'
+                  : 'Your spot for this free event is confirmed.'}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <section className="bg-white rounded-lg border border-gray-200 p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">{eventTitle}</h2>
+
+          {displayEvent?.eventDate && (
+            <p className="flex items-start gap-2 text-sm text-gray-700">
+              <Calendar className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
+              <span>{formatEventDate(displayEvent.eventDate)}</span>
+            </p>
+          )}
+
+          {venueLabel && (
+            <p className="flex items-start gap-2 text-sm text-gray-700">
+              <MapPin className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
+              <span>{venueLabel}</span>
+            </p>
+          )}
+
+          {guestInfo && (guestInfo.name || guestInfo.email) && (
+            <dl className="pt-2 border-t border-gray-100 text-sm space-y-1">
+              <dt className="text-gray-500 font-medium">Registered as</dt>
+              <dd className="text-gray-900">
+                {[guestInfo.name, guestInfo.email].filter(Boolean).join(' · ')}
+              </dd>
+            </dl>
+          )}
+
+          {isPaidFlow && paidTicketLabel && (
+            <dl className="pt-2 border-t border-gray-100 text-sm space-y-1">
+              <dt className="text-gray-500 font-medium">Ticket</dt>
+              <dd className="text-gray-900">{paidTicketLabel}</dd>
+            </dl>
+          )}
+
+          {isPaidFlow && paidState.transaction?.amount != null && (
+            <dl className="text-sm space-y-1">
+              <dt className="text-gray-500 font-medium">Amount paid</dt>
+              <dd className="text-gray-900">
+                {formatCurrency(pesewasToGhs(paidState.transaction.amount))}
+              </dd>
+            </dl>
+          )}
+
+          {isPaidFlow && reference && (
+            <p className="text-xs text-gray-500 font-mono pt-2">Payment reference: {reference}</p>
+          )}
+        </section>
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          {displayEvent?.slug && (
+            <Link to={`/events/${displayEvent.slug}`}>
+              <Button variant="ghost" className="px-4 py-2 text-sm">
+                View event
+              </Button>
+            </Link>
+          )}
+          <Link to="/events">
+            <Button variant="primary" className="px-4 py-2 text-sm">
+              Browse more events
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default EventConfirmation;

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -1,21 +1,16 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
 import { Calendar, MapPin, Users } from 'lucide-react';
 
 import SEO from '../components/SEO';
 import Button from '../components/ui/Button';
 import EventRegistrationPanel from '../components/events/EventRegistrationPanel';
+import EventTicketCheckout from '../components/events/EventTicketCheckout';
 import NotFound from '../components/ui/NotFound';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { useEvent } from '../hooks/queries/useEvents';
 import { EVENT_TYPE, EVENT_TYPE_LABELS } from '../constants/events';
-import { formatCurrency } from '../utils/admin/tableHelpers';
-import {
-  formatEventDate,
-  formatEventVenue,
-  getEventTypeColor,
-  pesewasToGhs,
-} from '../utils/events';
+import { formatEventDate, formatEventVenue, getEventTypeColor } from '../utils/events';
 import scrollToTop from '../utils/scrollToTop';
 
 const getSpotsLabel = spotsRemaining => {
@@ -30,11 +25,6 @@ const EventDetails = () => {
   const { data, isLoading, isError, error } = useEvent(slug);
 
   const event = data?.data || null;
-
-  const activeTickets = useMemo(
-    () => (event?.ticketTypes || []).filter(t => t.isActive),
-    [event?.ticketTypes]
-  );
 
   useEffect(() => {
     if (!isLoading && event) {
@@ -194,59 +184,7 @@ const EventDetails = () => {
               />
             )}
 
-            {isPaid && (
-              <section className="bg-white rounded-lg border border-gray-200 p-6">
-                <h2 className="text-lg font-semibold text-gray-900 mb-4">Tickets</h2>
-                {activeTickets.length === 0 ? (
-                  <p className="text-sm text-gray-500">Tickets are not available yet.</p>
-                ) : (
-                  <ul className="space-y-3 mb-4">
-                    {activeTickets.map(ticket => {
-                      const soldOut = ticket.remainingQuantity === 0;
-                      return (
-                        <li
-                          key={ticket._id}
-                          className={`rounded-lg border p-4 ${soldOut ? 'border-gray-200 bg-gray-50 opacity-75' : 'border-gray-200'}`}
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <div>
-                              <p className="font-medium text-gray-900">{ticket.name}</p>
-                              <p className="text-sm text-gray-600 mt-1">
-                                {formatCurrency(pesewasToGhs(ticket.pricePesewas))}
-                              </p>
-                            </div>
-                            {soldOut && (
-                              <span className="shrink-0 inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-gray-200 text-gray-700">
-                                Sold out
-                              </span>
-                            )}
-                          </div>
-                          <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-gray-600">
-                            <div>
-                              <dt className="text-gray-500">Available</dt>
-                              <dd className="font-medium text-gray-800">
-                                {ticket.remainingQuantity ?? 0}
-                              </dd>
-                            </div>
-                            {ticket.expiresAt && (
-                              <div>
-                                <dt className="text-gray-500">Sales end</dt>
-                                <dd className="font-medium text-gray-800">
-                                  {formatEventDate(ticket.expiresAt)}
-                                </dd>
-                              </div>
-                            )}
-                          </dl>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-                <Button variant="primary" className="w-full px-4 py-3 text-sm" disabled>
-                  Coming soon
-                </Button>
-              </section>
-            )}
+            {isPaid && <EventTicketCheckout event={event} />}
 
             {hasVolunteerForm && (
               <section className="bg-white rounded-lg border border-gray-200 p-6">

--- a/src/pages/PaymentCallback.jsx
+++ b/src/pages/PaymentCallback.jsx
@@ -4,6 +4,7 @@ import { verifyPayment } from '../api/payments';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { useCartDispatch } from '../contexts/cart/useCart';
 import { clearCart } from '../contexts/cart/cartActions';
+import { getPaymentCallbackDestination } from '../utils/events/paymentCallbackRouting';
 
 const PaymentCallback = () => {
   const [searchParams] = useSearchParams();
@@ -20,13 +21,22 @@ const PaymentCallback = () => {
     (async () => {
       try {
         const res = await verifyPayment(reference);
-        const orderId = res?.data?.order;
-        if (!orderId) throw new Error('Order not found after payment');
+        const destination = getPaymentCallbackDestination(res, reference);
 
-        // Clear cart after successful payment verification
+        if (destination.type === 'error') {
+          throw new Error(destination.message);
+        }
+
+        if (destination.type === 'event_ticket') {
+          navigate(
+            `/events/${destination.slug}/confirmation?reference=${encodeURIComponent(destination.reference)}`,
+            { replace: true }
+          );
+          return;
+        }
+
         cartDispatch(clearCart());
-
-        navigate(`/orders/${orderId}`, { replace: true });
+        navigate(`/orders/${destination.orderId}`, { replace: true });
       } catch (e) {
         setError(e?.message || 'Verification failed');
       }

--- a/src/utils/events/index.js
+++ b/src/utils/events/index.js
@@ -7,3 +7,8 @@ export {
   getVolunteerStatusColor,
 } from './statusBadges';
 export { validateEventForm } from './validateEventForm';
+export {
+  EVENT_CHECKOUT_SLUG_KEY,
+  getPaymentCallbackDestination,
+  resolveEventCheckoutSlug,
+} from './paymentCallbackRouting';

--- a/src/utils/events/paymentCallbackRouting.js
+++ b/src/utils/events/paymentCallbackRouting.js
@@ -1,0 +1,60 @@
+/** Persisted before Paystack redirect so PaymentCallback can route to the event confirmation page. */
+export const EVENT_CHECKOUT_SLUG_KEY = 'misqabbi_event_checkout_slug';
+
+/**
+ * Resolve event slug after Paystack verify for event_ticket transactions.
+ * Backend may return eventRegistration.event as an ObjectId; checkout stores slug in sessionStorage.
+ *
+ * @param {Object|null} transaction
+ * @param {Object|null} eventRegistration
+ * @returns {string|null}
+ */
+export const resolveEventCheckoutSlug = (transaction, eventRegistration) => {
+  const eventRef = eventRegistration?.event;
+  if (eventRef && typeof eventRef === 'object' && eventRef.slug) {
+    return eventRef.slug;
+  }
+
+  if (typeof window !== 'undefined') {
+    const stored = sessionStorage.getItem(EVENT_CHECKOUT_SLUG_KEY);
+    if (stored) {
+      sessionStorage.removeItem(EVENT_CHECKOUT_SLUG_KEY);
+      return stored;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Determine post-verify redirect path from payment verify API response.
+ *
+ * @param {Object} verifyResponse - { data: { transaction, order, eventRegistration } }
+ * @returns {{ type: 'order', orderId: string } | { type: 'event_ticket', slug: string, reference: string } | { type: 'error', message: string }}
+ */
+export const getPaymentCallbackDestination = (verifyResponse, reference) => {
+  const transaction = verifyResponse?.data?.transaction;
+  const orderId = verifyResponse?.data?.order?._id || verifyResponse?.data?.order;
+  const eventRegistration = verifyResponse?.data?.eventRegistration;
+
+  if (!transaction) {
+    return { type: 'error', message: 'Transaction not found after payment' };
+  }
+
+  if (transaction.purpose === 'event_ticket') {
+    const slug = resolveEventCheckoutSlug(transaction, eventRegistration);
+    if (!slug) {
+      return {
+        type: 'error',
+        message: 'Could not determine which event this payment belongs to.',
+      };
+    }
+    return { type: 'event_ticket', slug, reference };
+  }
+
+  if (!orderId) {
+    return { type: 'error', message: 'Order not found after payment' };
+  }
+
+  return { type: 'order', orderId: String(orderId) };
+};

--- a/tests/paymentCallbackRouting.test.js
+++ b/tests/paymentCallbackRouting.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import {
+  EVENT_CHECKOUT_SLUG_KEY,
+  getPaymentCallbackDestination,
+  resolveEventCheckoutSlug,
+} from '../src/utils/events/paymentCallbackRouting';
+
+describe('resolveEventCheckoutSlug', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns slug from populated eventRegistration.event', () => {
+    const slug = resolveEventCheckoutSlug(null, {
+      event: { slug: 'summer-gala' },
+    });
+    expect(slug).toBe('summer-gala');
+  });
+
+  it('falls back to sessionStorage and clears the key', () => {
+    sessionStorage.setItem(EVENT_CHECKOUT_SLUG_KEY, 'stored-event');
+    const slug = resolveEventCheckoutSlug(null, null);
+    expect(slug).toBe('stored-event');
+    expect(sessionStorage.getItem(EVENT_CHECKOUT_SLUG_KEY)).toBeNull();
+  });
+});
+
+describe('getPaymentCallbackDestination', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.stubGlobal('window', globalThis);
+  });
+
+  it('routes order payments to order detail', () => {
+    const destination = getPaymentCallbackDestination(
+      {
+        data: {
+          transaction: { purpose: 'order', status: 'success' },
+          order: 'order-123',
+        },
+      },
+      'ref-order'
+    );
+    expect(destination).toEqual({ type: 'order', orderId: 'order-123' });
+  });
+
+  it('routes event_ticket payments to event confirmation', () => {
+    sessionStorage.setItem(EVENT_CHECKOUT_SLUG_KEY, 'charity-run');
+    const destination = getPaymentCallbackDestination(
+      {
+        data: {
+          transaction: { purpose: 'event_ticket', status: 'success' },
+          eventRegistration: { _id: 'reg-1' },
+          order: null,
+        },
+      },
+      'ref-event'
+    );
+    expect(destination).toEqual({
+      type: 'event_ticket',
+      slug: 'charity-run',
+      reference: 'ref-event',
+    });
+  });
+
+  it('returns error when event slug cannot be resolved', () => {
+    const destination = getPaymentCallbackDestination(
+      {
+        data: {
+          transaction: { purpose: 'event_ticket', status: 'success' },
+          eventRegistration: { event: '507f1f77bcf86cd799439011' },
+        },
+      },
+      'ref-event'
+    );
+    expect(destination.type).toBe('error');
+  });
+});


### PR DESCRIPTION
Add paid event ticket checkout on the public event detail page with Paystack redirect, payment callback routing for event tickets, and a shared confirmation page for paid and free registrations.

- Add EventTicketCheckout with ticket selection, quantity, registration form, and Paystack redirect
- Add EventConfirmation page for paid verify-by-reference and free location.state from Branch 9
- Route PaymentCallback by transaction purpose without clearing cart for event tickets
- Wire checkout on EventDetails and register confirmation route in App.jsx
