### PR TITLE
Fix event FormData hygiene

### DIFF
--- a/src/api/adminEvents.js
+++ b/src/api/adminEvents.js
@@ -13,6 +13,12 @@ const buildQueryString = params => {
   return qs.toString();
 };
 
+const appendNonEmptyString = (formData, key, value) => {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (trimmed) formData.append(key, trimmed);
+};
+
 /**
  * Build FormData for event create/update with optional banner file.
  * @param {Object} data - Event fields
@@ -25,12 +31,14 @@ export const buildEventFormData = (data, bannerFile) => {
   if (data.description != null) formData.append('description', data.description);
   if (data.eventDate != null) formData.append('eventDate', data.eventDate);
   if (data.type != null) formData.append('type', data.type);
-  if (data.maxAttendees != null) formData.append('maxAttendees', String(data.maxAttendees));
-  if (data.venue?.name != null) formData.append('venue[name]', data.venue.name);
-  if (data.venue?.address != null) formData.append('venue[address]', data.venue.address);
-  if (data.venue?.url != null) formData.append('venue[url]', data.venue.url);
-  if (data.banner === null) formData.append('banner', '');
-  if (bannerFile) formData.append('banner', bannerFile);
+  const maxAttendees = Number(data.maxAttendees);
+  if (Number.isFinite(maxAttendees) && maxAttendees > 0) {
+    formData.append('maxAttendees', String(Math.trunc(maxAttendees)));
+  }
+  appendNonEmptyString(formData, 'venue[name]', data.venue?.name);
+  appendNonEmptyString(formData, 'venue[address]', data.venue?.address);
+  appendNonEmptyString(formData, 'venue[url]', data.venue?.url);
+  if (bannerFile instanceof File) formData.append('banner', bannerFile);
   return formData;
 };
 
@@ -84,7 +92,7 @@ export const getAdminEventById = async id => {
  * @returns {Promise<{ success, data: event }>}
  */
 export const updateAdminEvent = async (id, data, bannerFile) => {
-  if (bannerFile || data.banner === null) {
+  if (bannerFile) {
     const formData = buildEventFormData(data, bannerFile);
     const res = await axios.patch(`${BASE}/${id}`, formData, withCredentials);
     if (!res.data?.success) throw new Error(res.data?.error || 'Failed to update event');

--- a/src/api/adminEvents.js
+++ b/src/api/adminEvents.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { decodeHtmlEntities } from '../utils/decodeHtmlEntities';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api/v1';
 const BASE = `${API_URL}/admin/events`;
@@ -15,7 +16,7 @@ const buildQueryString = params => {
 
 const appendNonEmptyString = (formData, key, value) => {
   if (typeof value !== 'string') return;
-  const trimmed = value.trim();
+  const trimmed = decodeHtmlEntities(value).trim();
   if (trimmed) formData.append(key, trimmed);
 };
 
@@ -27,10 +28,10 @@ const appendNonEmptyString = (formData, key, value) => {
  */
 export const buildEventFormData = (data, bannerFile) => {
   const formData = new FormData();
-  if (data.name != null) formData.append('name', data.name);
+  if (data.name != null) formData.append('name', decodeHtmlEntities(data.name));
   if (data.description != null) formData.append('description', data.description);
-  if (data.eventDate != null) formData.append('eventDate', data.eventDate);
-  if (data.type != null) formData.append('type', data.type);
+  if (data.eventDate != null) formData.append('eventDate', decodeHtmlEntities(data.eventDate));
+  if (data.type != null) formData.append('type', decodeHtmlEntities(data.type));
   const maxAttendees = Number(data.maxAttendees);
   if (Number.isFinite(maxAttendees) && maxAttendees > 0) {
     formData.append('maxAttendees', String(Math.trunc(maxAttendees)));

--- a/src/components/admin/EventForm.jsx
+++ b/src/components/admin/EventForm.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import FormField from './FormField';
 import { EVENT_TYPE, EVENT_TYPES, EVENT_TYPE_LABELS } from '../../constants/events';
+import { decodeHtmlEntities } from '../../utils/decodeHtmlEntities';
 
 const TYPE_OPTIONS = EVENT_TYPES.map(value => ({
   value,
@@ -60,16 +61,16 @@ const EventForm = ({ initialData = null, onSubmit, isLoading, error: submitError
     }
 
     const venue = {
-      name: formData.venueName.trim(),
-      address: formData.venueAddress.trim(),
-      url: formData.venueUrl.trim(),
+      name: decodeHtmlEntities(formData.venueName).trim(),
+      address: decodeHtmlEntities(formData.venueAddress).trim(),
+      url: decodeHtmlEntities(formData.venueUrl).trim(),
     };
 
     const payload = {
-      name: formData.name.trim(),
+      name: decodeHtmlEntities(formData.name).trim(),
       description: formData.description,
-      eventDate: new Date(formData.eventDate).toISOString(),
-      type: formData.type,
+      eventDate: new Date(decodeHtmlEntities(formData.eventDate)).toISOString(),
+      type: decodeHtmlEntities(formData.type),
       maxAttendees,
     };
     if (venue.name || venue.address || venue.url) payload.venue = venue;

--- a/src/components/admin/EventForm.jsx
+++ b/src/components/admin/EventForm.jsx
@@ -38,30 +38,52 @@ const EventForm = ({ initialData = null, onSubmit, isLoading, error: submitError
       removeBanner: false,
     };
   });
+  const [validationErrors, setValidationErrors] = useState({});
 
-  const update = (key, value) => setFormData(prev => ({ ...prev, [key]: value }));
+  const update = (key, value) => {
+    setFormData(prev => ({ ...prev, [key]: value }));
+    if (key === 'maxAttendees') {
+      setValidationErrors(prev => {
+        if (!prev.maxAttendees) return prev;
+        const next = { ...prev };
+        delete next.maxAttendees;
+        return next;
+      });
+    }
+  };
 
   const buildPayload = () => {
+    const maxAttendees = Number(formData.maxAttendees);
+    if (!Number.isInteger(maxAttendees) || maxAttendees <= 0) {
+      setValidationErrors({ maxAttendees: 'Max attendees must be a positive whole number.' });
+      return null;
+    }
+
+    const venue = {
+      name: formData.venueName.trim(),
+      address: formData.venueAddress.trim(),
+      url: formData.venueUrl.trim(),
+    };
+
     const payload = {
       name: formData.name.trim(),
       description: formData.description,
       eventDate: new Date(formData.eventDate).toISOString(),
       type: formData.type,
-      maxAttendees: Number(formData.maxAttendees),
-      venue: {
-        name: formData.venueName.trim(),
-        address: formData.venueAddress.trim(),
-        url: formData.venueUrl.trim(),
-      },
+      maxAttendees,
     };
+    if (venue.name || venue.address || venue.url) payload.venue = venue;
     if (formData.removeBanner) payload.banner = null;
+    setValidationErrors({});
     return payload;
   };
 
   const handleSubmit = e => {
     e.preventDefault();
+    const payload = buildPayload();
+    if (!payload) return;
     onSubmit({
-      data: buildPayload(),
+      data: payload,
       bannerFile: formData.bannerFile?.[0] || null,
     });
   };
@@ -114,6 +136,7 @@ const EventForm = ({ initialData = null, onSubmit, isLoading, error: submitError
         value={formData.maxAttendees}
         onChange={value => update('maxAttendees', value)}
         placeholder="100"
+        error={validationErrors.maxAttendees}
         required
       />
 

--- a/src/utils/decodeHtmlEntities.js
+++ b/src/utils/decodeHtmlEntities.js
@@ -1,0 +1,18 @@
+const HTML_ENTITIES = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#x27;': "'",
+  '&#x2F;': '/',
+  '&#39;': "'",
+  '&#47;': '/',
+};
+
+export const decodeHtmlEntities = value => {
+  if (typeof value !== 'string') return value;
+  return value.replace(
+    /&(amp|lt|gt|quot);|&#x(27|2F);|&#(39|47);/gi,
+    entity => HTML_ENTITIES[entity] ?? HTML_ENTITIES[entity.toLowerCase()] ?? entity
+  );
+};

--- a/tests/buildEventFormData.test.js
+++ b/tests/buildEventFormData.test.js
@@ -47,4 +47,18 @@ describe('buildEventFormData', () => {
     expect(formData.get('venue[url]')).toBe('https://maps.example.com');
     expect(formData.has('venue')).toBe(false);
   });
+
+  test('decodes HTML entities from scalar fields before appending', () => {
+    const formData = buildEventFormData(
+      {
+        name: 'Summer &#x2F; Showcase',
+        eventDate: '2026-07-01T10:00:00.000Z',
+        venue: { url: 'https:&#x2F;&#x2F;maps.example.com&#x2F;event' },
+      },
+      null
+    );
+
+    expect(formData.get('name')).toBe('Summer / Showcase');
+    expect(formData.get('venue[url]')).toBe('https://maps.example.com/event');
+  });
 });

--- a/tests/buildEventFormData.test.js
+++ b/tests/buildEventFormData.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildEventFormData } from '../src/api/adminEvents';
+
+describe('buildEventFormData', () => {
+  test('appends a selected banner file once', () => {
+    const banner = new File(['banner'], 'banner.png', { type: 'image/png' });
+    const formData = buildEventFormData({ maxAttendees: 50 }, banner);
+
+    expect(formData.getAll('banner')).toEqual([banner]);
+  });
+
+  test('does not append banner without a file, including banner null', () => {
+    const formData = buildEventFormData({ banner: null, maxAttendees: 50 }, null);
+
+    expect(formData.has('banner')).toBe(false);
+  });
+
+  test('appends maxAttendees as a numeric string', () => {
+    const formData = buildEventFormData({ maxAttendees: 50 }, null);
+
+    expect(formData.get('maxAttendees')).toBe('50');
+  });
+
+  test('skips empty or invalid maxAttendees values', () => {
+    expect(buildEventFormData({ maxAttendees: '' }, null).has('maxAttendees')).toBe(false);
+    expect(buildEventFormData({ maxAttendees: Number.NaN }, null).has('maxAttendees')).toBe(false);
+  });
+
+  test('omits venue fields when they are empty', () => {
+    const formData = buildEventFormData(
+      { venue: { name: '', address: '   ', url: '' }, maxAttendees: 50 },
+      null
+    );
+
+    expect(Array.from(formData.keys()).some(key => key.startsWith('venue['))).toBe(false);
+  });
+
+  test('appends only non-empty venue fields with bracket notation', () => {
+    const formData = buildEventFormData(
+      { venue: { name: 'Misqabbi Studio', address: '', url: 'https://maps.example.com' } },
+      null
+    );
+
+    expect(formData.get('venue[name]')).toBe('Misqabbi Studio');
+    expect(formData.has('venue[address]')).toBe(false);
+    expect(formData.get('venue[url]')).toBe('https://maps.example.com');
+    expect(formData.has('venue')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fix admin event create and update payload hygiene so backend validation no longer receives empty multipart fields or HTML-escaped scalar values. Banner removal now uses the supported JSON banner: null contract while rich-text descriptions remain separate from scalar field handling.

- Send multipart only when uploading an actual banner file and never append banner: ""
- Normalize maxAttendees, omit empty venue fields, and keep venue keys in bracket notation for multipart requests
- Decode HTML entities from event scalar fields before JSON or FormData submit, with focused FormData regression coverage