### PR TITLE
Refine event form and listing UI

### DIFF
--- a/src/components/admin/AdminEventDetailLayout.jsx
+++ b/src/components/admin/AdminEventDetailLayout.jsx
@@ -14,7 +14,6 @@ export const DETAIL_TABS = [
 const AdminEventDetailLayout = ({
   event,
   eventId,
-  onBack,
   onEdit,
   canPublish,
   canCancel,
@@ -31,16 +30,9 @@ const AdminEventDetailLayout = ({
     <div>
       <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
-          <button
-            className="mb-2 px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
-            onClick={onBack}
-          >
-            Back to events
-          </button>
           <h1 className="text-2xl font-bebas text-msq-purple-rich uppercase tracking-wide">
             {event.name}
           </h1>
-          <p className="text-sm text-gray-500 mt-1">/{event.slug}</p>
         </div>
         <div className="flex flex-wrap gap-2">
           <button

--- a/src/components/admin/BuiltinFieldsEditor.jsx
+++ b/src/components/admin/BuiltinFieldsEditor.jsx
@@ -33,16 +33,13 @@ const BuiltinFieldsEditor = ({ builtinFields = [], onChange }) => {
   return (
     <div className="space-y-3">
       <h3 className="text-sm font-medium text-gray-900">Identity fields</h3>
-      <p className="text-xs text-gray-500">
-        Choose which contact fields appear on the form and whether each is required.
-      </p>
       <ul className="space-y-2">
         {BUILTIN_FORM_FIELDS.map(field => {
           const enabled = isEnabled(field);
           return (
             <li
               key={field}
-              className="flex flex-wrap items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+              className="flex flex-wrap items-center gap-3 rounded-lg bg-gray-50/60 px-3 py-2 shadow-sm"
             >
               <label className="flex items-center gap-2 text-sm text-gray-700">
                 <input

--- a/src/components/admin/CustomQuestionsEditor.jsx
+++ b/src/components/admin/CustomQuestionsEditor.jsx
@@ -1,3 +1,5 @@
+import { Plus } from 'lucide-react';
+
 import { FORM_QUESTION_TYPE, FORM_QUESTION_TYPES } from '../../constants/events';
 
 const TYPE_LABELS = {
@@ -8,6 +10,8 @@ const TYPE_LABELS = {
 };
 
 const createQuestionId = () => `q_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+
+const getQuestionOptions = question => (question.options?.length ? question.options : ['Option 1']);
 
 const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
   const addQuestion = () => {
@@ -39,12 +43,40 @@ const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
     onChange(next);
   };
 
-  const updateOptions = (index, raw) => {
-    const options = raw
-      .split('\n')
-      .map(line => line.trim())
-      .filter(Boolean);
-    updateQuestion(index, { options });
+  const updateOption = (questionIndex, optionIndex, value) => {
+    const question = customQuestions[questionIndex];
+    const options = [...getQuestionOptions(question)];
+    options[optionIndex] = value;
+    updateQuestion(questionIndex, { options });
+  };
+
+  const addOption = questionIndex => {
+    const question = customQuestions[questionIndex];
+    const options = getQuestionOptions(question);
+    updateQuestion(questionIndex, { options: [...options, `Option ${options.length + 1}`] });
+  };
+
+  const removeOption = (questionIndex, optionIndex) => {
+    const question = customQuestions[questionIndex];
+    const options = getQuestionOptions(question);
+    if (options.length <= 1) return;
+    updateQuestion(questionIndex, { options: options.filter((_, i) => i !== optionIndex) });
+  };
+
+  const moveOption = (questionIndex, optionIndex, direction) => {
+    const question = customQuestions[questionIndex];
+    const options = getQuestionOptions(question);
+    const target = optionIndex + direction;
+    if (target < 0 || target >= options.length) return;
+    const next = [...options];
+    [next[optionIndex], next[target]] = [next[target], next[optionIndex]];
+    updateQuestion(questionIndex, { options: next });
+  };
+
+  const normalizeOptions = questionIndex => {
+    const question = customQuestions[questionIndex];
+    const options = (question.options || []).map(option => option.trim()).filter(Boolean);
+    updateQuestion(questionIndex, { options: options.length ? options : ['Option 1'] });
   };
 
   return (
@@ -114,14 +146,53 @@ const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
               </div>
 
               {question.type === FORM_QUESTION_TYPE.SELECT && (
-                <div>
-                  <label className="block text-xs text-gray-500 mb-1">Options (one per line)</label>
-                  <textarea
-                    rows={3}
-                    value={(question.options || []).join('\n')}
-                    onChange={e => updateOptions(index, e.target.value)}
-                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md"
-                  />
+                <div className="space-y-2">
+                  <label className="block text-xs text-gray-500">Options</label>
+                  <ul className="space-y-2">
+                    {getQuestionOptions(question).map((option, optionIndex) => (
+                      <li key={optionIndex} className="flex flex-wrap items-center gap-2">
+                        <input
+                          type="text"
+                          value={option}
+                          onChange={e => updateOption(index, optionIndex, e.target.value)}
+                          onBlur={() => normalizeOptions(index)}
+                          className="min-w-[200px] flex-1 px-3 py-2 text-sm border border-gray-200 rounded-md"
+                        />
+                        <button
+                          type="button"
+                          disabled={optionIndex === 0}
+                          onClick={() => moveOption(index, optionIndex, -1)}
+                          className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                        >
+                          Move up
+                        </button>
+                        <button
+                          type="button"
+                          disabled={optionIndex === getQuestionOptions(question).length - 1}
+                          onClick={() => moveOption(index, optionIndex, 1)}
+                          className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                        >
+                          Move down
+                        </button>
+                        <button
+                          type="button"
+                          disabled={getQuestionOptions(question).length <= 1}
+                          onClick={() => removeOption(index, optionIndex)}
+                          className="px-2 py-1 text-xs text-red-600 bg-red-50 rounded hover:bg-red-100 disabled:opacity-40"
+                        >
+                          Remove
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                  <button
+                    type="button"
+                    onClick={() => addOption(index)}
+                    className="inline-flex items-center px-3 py-1.5 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+                  >
+                    <Plus className="h-4 w-4 mr-1" />
+                    Add option
+                  </button>
                 </div>
               )}
 

--- a/src/components/admin/CustomQuestionsEditor.jsx
+++ b/src/components/admin/CustomQuestionsEditor.jsx
@@ -1,4 +1,4 @@
-import { Plus } from 'lucide-react';
+import { ChevronDown, ChevronUp, Plus, Trash2 } from 'lucide-react';
 
 import { FORM_QUESTION_TYPE, FORM_QUESTION_TYPES } from '../../constants/events';
 
@@ -12,6 +12,12 @@ const TYPE_LABELS = {
 const createQuestionId = () => `q_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
 
 const getQuestionOptions = question => (question.options?.length ? question.options : ['Option 1']);
+
+const inputClass =
+  'w-full rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-100 outline-none transition focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30';
+const labelClass = 'block text-left text-xs font-medium text-gray-500 mb-1';
+const iconButtonClass =
+  'inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 disabled:pointer-events-none disabled:opacity-30';
 
 const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
   const addQuestion = () => {
@@ -80,19 +86,15 @@ const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       <div className="flex items-center justify-between gap-3">
-        <div>
-          <h3 className="text-sm font-medium text-gray-900">Custom questions</h3>
-          <p className="text-xs text-gray-500">
-            Add optional questions beyond the identity fields.
-          </p>
-        </div>
+        <h3 className="text-sm font-medium text-gray-900">Custom questions</h3>
         <button
           type="button"
           onClick={addQuestion}
-          className="px-3 py-1.5 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+          className="inline-flex items-center rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-800 transition hover:bg-gray-200"
         >
+          <Plus className="mr-1 h-4 w-4" />
           Add question
         </button>
       </div>
@@ -102,19 +104,19 @@ const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
       ) : (
         <ul className="space-y-4">
           {customQuestions.map((question, index) => (
-            <li key={question.id} className="rounded-lg border border-gray-200 p-4 space-y-3">
+            <li key={question.id} className="space-y-4 rounded-xl bg-gray-50/60 p-4 shadow-sm">
               <div className="flex flex-wrap items-start gap-3">
                 <div className="flex-1 min-w-[200px]">
-                  <label className="block text-xs text-gray-500 mb-1">Label</label>
+                  <label className={labelClass}>Label</label>
                   <input
                     type="text"
                     value={question.label}
                     onChange={e => updateQuestion(index, { label: e.target.value })}
-                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md"
+                    className={inputClass}
                   />
                 </div>
                 <div className="w-40">
-                  <label className="block text-xs text-gray-500 mb-1">Type</label>
+                  <label className={labelClass}>Type</label>
                   <select
                     value={question.type}
                     onChange={e => {
@@ -125,7 +127,7 @@ const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
                       }
                       updateQuestion(index, patch);
                     }}
-                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md"
+                    className={inputClass}
                   >
                     {FORM_QUESTION_TYPES.map(type => (
                       <option key={type} value={type}>
@@ -147,40 +149,46 @@ const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
 
               {question.type === FORM_QUESTION_TYPE.SELECT && (
                 <div className="space-y-2">
-                  <label className="block text-xs text-gray-500">Options</label>
+                  <label className={labelClass}>Options</label>
                   <ul className="space-y-2">
                     {getQuestionOptions(question).map((option, optionIndex) => (
-                      <li key={optionIndex} className="flex flex-wrap items-center gap-2">
+                      <li key={optionIndex} className="flex flex-wrap items-center gap-1.5">
                         <input
                           type="text"
                           value={option}
                           onChange={e => updateOption(index, optionIndex, e.target.value)}
                           onBlur={() => normalizeOptions(index)}
-                          className="min-w-[200px] flex-1 px-3 py-2 text-sm border border-gray-200 rounded-md"
+                          className={`${inputClass} min-w-[200px] flex-1`}
                         />
                         <button
                           type="button"
                           disabled={optionIndex === 0}
                           onClick={() => moveOption(index, optionIndex, -1)}
-                          className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                          className={iconButtonClass}
+                          aria-label="Move option up"
+                          title="Move option up"
                         >
-                          Move up
+                          <ChevronUp className="h-4 w-4" />
                         </button>
                         <button
                           type="button"
                           disabled={optionIndex === getQuestionOptions(question).length - 1}
                           onClick={() => moveOption(index, optionIndex, 1)}
-                          className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                          className={iconButtonClass}
+                          aria-label="Move option down"
+                          title="Move option down"
                         >
-                          Move down
+                          <ChevronDown className="h-4 w-4" />
                         </button>
                         <button
                           type="button"
                           disabled={getQuestionOptions(question).length <= 1}
                           onClick={() => removeOption(index, optionIndex)}
-                          className="px-2 py-1 text-xs text-red-600 bg-red-50 rounded hover:bg-red-100 disabled:opacity-40"
+                          className={`${iconButtonClass} text-red-500 hover:bg-red-50 hover:text-red-600`}
+                          aria-label="Remove option"
+                          title="Remove option"
                         >
-                          Remove
+                          <Trash2 className="h-4 w-4" />
                         </button>
                       </li>
                     ))}
@@ -188,37 +196,43 @@ const CustomQuestionsEditor = ({ customQuestions = [], onChange }) => {
                   <button
                     type="button"
                     onClick={() => addOption(index)}
-                    className="inline-flex items-center px-3 py-1.5 text-sm bg-gray-100 rounded-md hover:bg-gray-200"
+                    className="inline-flex items-center rounded-md px-2.5 py-1.5 text-sm text-gray-700 transition hover:bg-gray-100 hover:text-gray-900"
                   >
-                    <Plus className="h-4 w-4 mr-1" />
+                    <Plus className="mr-1 h-4 w-4" />
                     Add option
                   </button>
                 </div>
               )}
 
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap justify-end gap-1">
                 <button
                   type="button"
                   disabled={index === 0}
                   onClick={() => moveQuestion(index, -1)}
-                  className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                  className={iconButtonClass}
+                  aria-label="Move question up"
+                  title="Move question up"
                 >
-                  Move up
+                  <ChevronUp className="h-4 w-4" />
                 </button>
                 <button
                   type="button"
                   disabled={index === customQuestions.length - 1}
                   onClick={() => moveQuestion(index, 1)}
-                  className="px-2 py-1 text-xs bg-gray-100 rounded disabled:opacity-40"
+                  className={iconButtonClass}
+                  aria-label="Move question down"
+                  title="Move question down"
                 >
-                  Move down
+                  <ChevronDown className="h-4 w-4" />
                 </button>
                 <button
                   type="button"
                   onClick={() => removeQuestion(index)}
-                  className="px-2 py-1 text-xs text-red-600 bg-red-50 rounded hover:bg-red-100 ml-auto"
+                  className={`${iconButtonClass} text-red-500 hover:bg-red-50 hover:text-red-600`}
+                  aria-label="Remove question"
+                  title="Remove question"
                 >
-                  Remove
+                  <Trash2 className="h-4 w-4" />
                 </button>
               </div>
             </li>

--- a/src/components/admin/EventFormBuilder.jsx
+++ b/src/components/admin/EventFormBuilder.jsx
@@ -13,17 +13,25 @@ export const DEFAULT_FORM_SCHEMA = {
   customQuestions: [],
 };
 
+const createDefaultFormSchema = () => ({
+  builtinFields: DEFAULT_FORM_SCHEMA.builtinFields.map(fieldConfig => ({ ...fieldConfig })),
+  customQuestions: [],
+});
+
 const EventFormBuilder = ({
   title,
   description,
   identityKey = 'guestInfo',
   initialSchema,
+  isConfigured = Boolean(initialSchema),
   isLoading,
   loadError,
   onSave,
   isSaving,
+  setupLabel,
 }) => {
-  const [schema, setSchema] = useState(DEFAULT_FORM_SCHEMA);
+  const [schema, setSchema] = useState(createDefaultFormSchema);
+  const [builderOpen, setBuilderOpen] = useState(false);
   const [saveError, setSaveError] = useState(null);
 
   useEffect(() => {
@@ -32,8 +40,12 @@ const EventFormBuilder = ({
         builtinFields: initialSchema.builtinFields ?? DEFAULT_FORM_SCHEMA.builtinFields,
         customQuestions: initialSchema.customQuestions ?? [],
       });
+      setBuilderOpen(false);
+    } else if (!isConfigured) {
+      setSchema(createDefaultFormSchema());
+      setBuilderOpen(false);
     }
-  }, [initialSchema]);
+  }, [initialSchema, isConfigured]);
 
   const handleSave = async () => {
     if (!schema.builtinFields.length) {
@@ -43,7 +55,7 @@ const EventFormBuilder = ({
     setSaveError(null);
     try {
       await onSave(schema);
-      showSuccessToast('Form saved');
+      showSuccessToast(isConfigured ? 'Form saved' : 'Form created');
     } catch (err) {
       const msg = err?.response?.data?.error || err?.message || 'Failed to save form';
       setSaveError(msg);
@@ -51,12 +63,36 @@ const EventFormBuilder = ({
     }
   };
 
+  const shouldShowBuilder = isConfigured || builderOpen;
+  const ctaLabel = setupLabel || `Set up ${title.toLowerCase()}`;
+  const saveLabel = isConfigured ? 'Save form' : 'Create form';
+
   if (isLoading) {
     return <p className="text-sm text-gray-500">Loading form…</p>;
   }
 
   if (loadError) {
     return <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">{loadError}</div>;
+  }
+
+  if (!shouldShowBuilder) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        {description && <p className="text-sm text-gray-500 mt-1">{description}</p>}
+        <p className="text-sm text-gray-600 mt-4">
+          This form has not been set up yet. Start with the default name and email fields, then
+          customize the questions before saving.
+        </p>
+        <button
+          type="button"
+          onClick={() => setBuilderOpen(true)}
+          className="mt-4 px-4 py-2 text-sm bg-msq-purple-rich text-white rounded-md shadow-sm hover:bg-msq-purple-deep cursor-pointer"
+        >
+          {ctaLabel}
+        </button>
+      </div>
+    );
   }
 
   return (
@@ -91,7 +127,7 @@ const EventFormBuilder = ({
           onClick={handleSave}
           className="px-4 py-2 text-sm bg-msq-purple-rich text-white rounded-md hover:bg-msq-purple-deep disabled:opacity-50"
         >
-          {isSaving ? 'Saving…' : 'Save form'}
+          {isSaving ? 'Saving…' : saveLabel}
         </button>
       </div>
     </div>

--- a/src/components/admin/EventFormBuilder.jsx
+++ b/src/components/admin/EventFormBuilder.jsx
@@ -20,7 +20,6 @@ const createDefaultFormSchema = () => ({
 
 const EventFormBuilder = ({
   title,
-  description,
   identityKey = 'guestInfo',
   initialSchema,
   isConfigured = Boolean(initialSchema),
@@ -79,7 +78,6 @@ const EventFormBuilder = ({
     return (
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
         <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-        {description && <p className="text-sm text-gray-500 mt-1">{description}</p>}
         <p className="text-sm text-gray-600 mt-4">
           This form has not been set up yet. Start with the default name and email fields, then
           customize the questions before saving.
@@ -99,11 +97,10 @@ const EventFormBuilder = ({
     <div className="space-y-6">
       <div>
         <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-        {description && <p className="text-sm text-gray-500 mt-1">{description}</p>}
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="space-y-6 bg-white rounded-lg border border-gray-200 p-4">
+        <div className="space-y-6 rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-100">
           <BuiltinFieldsEditor
             builtinFields={schema.builtinFields}
             onChange={builtinFields => setSchema(prev => ({ ...prev, builtinFields }))}

--- a/src/components/events/DynamicEventForm.jsx
+++ b/src/components/events/DynamicEventForm.jsx
@@ -38,10 +38,10 @@ const DynamicEventForm = ({
   const customErrors = errors.customAnswers || {};
 
   const baseInputClass =
-    'w-full px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-msq-purple-rich/30';
-  const readOnlyInputClass = `${baseInputClass} border-gray-200 bg-gray-50 text-gray-700`;
+    'w-full rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-100 outline-none transition focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30 disabled:cursor-not-allowed';
+  const readOnlyInputClass = `${baseInputClass} text-gray-700`;
   const interactiveInputClass = fieldError =>
-    `${baseInputClass} bg-white text-gray-900 ${fieldError ? 'border-red-500' : 'border-gray-300'}`;
+    `${baseInputClass} ${fieldError ? 'ring-red-300 focus:ring-red-300' : ''}`;
 
   const renderBuiltinField = ({ field, required }) => {
     const fieldError = identityErrors[field];

--- a/src/components/events/DynamicEventForm.jsx
+++ b/src/components/events/DynamicEventForm.jsx
@@ -50,7 +50,7 @@ const DynamicEventForm = ({
       <div key={field} className="mb-4">
         <label
           htmlFor={`${identityKey}-${field}`}
-          className="block text-sm font-medium text-gray-700 mb-1"
+          className="mb-1 block text-left text-sm font-medium text-gray-700"
         >
           {BUILTIN_LABELS[field] || field}
           {required && <span className="text-red-500 ml-1">*</span>}
@@ -88,7 +88,7 @@ const DynamicEventForm = ({
           <div key={id} className="mb-4">
             <label
               htmlFor={`question-${id}`}
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="mb-1 block text-left text-sm font-medium text-gray-700"
             >
               {label}
               {required && <span className="text-red-500 ml-1">*</span>}
@@ -117,7 +117,7 @@ const DynamicEventForm = ({
           <div key={id} className="mb-4">
             <label
               htmlFor={`question-${id}`}
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="mb-1 block text-left text-sm font-medium text-gray-700"
             >
               {label}
               {required && <span className="text-red-500 ml-1">*</span>}
@@ -179,7 +179,7 @@ const DynamicEventForm = ({
           <div key={id} className="mb-4">
             <label
               htmlFor={`question-${id}`}
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="mb-1 block text-left text-sm font-medium text-gray-700"
             >
               {label}
               {required && <span className="text-red-500 ml-1">*</span>}

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -39,24 +39,24 @@ const EventCard = ({ event }) => {
           </span>
         </div>
       </Link>
-      <div className="px-4 py-2">
+      <div className="py-2 text-center">
         <Link to={`/events/${event.slug}`}>
-          <h3 className="text-xs sm:text-xs md:text-sm lg:text-lg font-medium text-msq-purple uppercase text-left tracking-wide hover:text-msq-purple-rich transition-colors">
+          <h3 className="text-xs sm:text-xs md:text-sm lg:text-lg font-medium text-msq-purple uppercase tracking-wide hover:text-msq-purple-rich transition-colors">
             {event.name}
           </h3>
         </Link>
-        <p className="mt-1 text-xs sm:text-sm text-gray-600 flex items-start gap-1">
+        <p className="mt-1 flex items-start justify-center gap-1 text-xs text-gray-600 sm:text-sm">
           <Calendar className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
           <span>{formatEventDate(event.eventDate)}</span>
         </p>
         {venueLabel && (
-          <p className="mt-0.5 text-xs sm:text-sm text-gray-600 flex items-start gap-1">
+          <p className="mt-0.5 flex items-start justify-center gap-1 text-xs text-gray-600 sm:text-sm">
             <MapPin className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
             <span className="line-clamp-2">{venueLabel}</span>
           </p>
         )}
         {spotsLabel && (
-          <p className="mt-1 text-xs sm:text-sm font-medium text-msq-purple-deep flex items-center gap-1">
+          <p className="mt-1 flex items-center justify-center gap-1 text-xs font-medium text-msq-purple-deep sm:text-sm">
             <Users className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
             <span>{spotsLabel}</span>
           </p>

--- a/src/components/events/EventRegistrationPanel.jsx
+++ b/src/components/events/EventRegistrationPanel.jsx
@@ -7,6 +7,8 @@ import { validateEventForm } from '../../utils/events/validateEventForm';
 import Button from '../ui/Button';
 import DynamicEventForm from './DynamicEventForm';
 
+const panelClass = 'rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100 sm:p-6';
+
 const buildInitialGuestInfo = (formSchema, currentUser) => {
   const guestInfo = {};
   const fields = formSchema?.builtinFields || [];
@@ -133,7 +135,7 @@ const EventRegistrationPanel = ({ event, onSuccess }) => {
 
   if (!registrationForm) {
     return (
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className={panelClass}>
         <h2 className="text-lg font-semibold text-gray-900 mb-2">Registration</h2>
         <p className="text-sm text-gray-500">Registration is not available for this event yet.</p>
       </section>
@@ -141,7 +143,7 @@ const EventRegistrationPanel = ({ event, onSuccess }) => {
   }
 
   return (
-    <section className="bg-white rounded-lg border border-gray-200 p-6">
+    <section className={panelClass}>
       <h2 className="text-lg font-semibold text-gray-900 mb-2">Registration</h2>
       <p className="text-sm text-gray-600 mb-4">
         Reserve your spot for this free event. Fill in the details below to register.

--- a/src/components/events/EventTicketCheckout.jsx
+++ b/src/components/events/EventTicketCheckout.jsx
@@ -9,6 +9,9 @@ import Button from '../ui/Button';
 import DynamicEventForm from './DynamicEventForm';
 
 const EVENT_CHECKOUT_SLUG_KEY = 'misqabbi_event_checkout_slug';
+const panelClass = 'rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100 sm:p-6';
+const inputClass =
+  'rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-100 outline-none transition focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30';
 
 const buildInitialGuestInfo = (formSchema, currentUser) => {
   const guestInfo = {};
@@ -171,7 +174,7 @@ const EventTicketCheckout = ({ event }) => {
 
   if (activeTickets.length === 0) {
     return (
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className={panelClass}>
         <h2 className="text-lg font-semibold text-gray-900 mb-2">Tickets</h2>
         <p className="text-sm text-gray-500">Tickets are not available yet.</p>
       </section>
@@ -180,7 +183,7 @@ const EventTicketCheckout = ({ event }) => {
 
   if (!registrationForm) {
     return (
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className={panelClass}>
         <h2 className="text-lg font-semibold text-gray-900 mb-2">Tickets</h2>
         <p className="text-sm text-gray-500">Registration is not available for this event yet.</p>
       </section>
@@ -188,7 +191,7 @@ const EventTicketCheckout = ({ event }) => {
   }
 
   return (
-    <section className="bg-white rounded-lg border border-gray-200 p-6">
+    <section className={panelClass}>
       <h2 className="text-lg font-semibold text-gray-900 mb-2">Get tickets</h2>
       <p className="text-sm text-gray-600 mb-4">
         Select a ticket type and complete the registration form to proceed to payment.
@@ -207,12 +210,12 @@ const EventTicketCheckout = ({ event }) => {
                 return (
                   <li key={ticket._id}>
                     <label
-                      className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer ${
+                      className={`flex items-start gap-3 rounded-lg p-3 shadow-sm ring-1 cursor-pointer ${
                         soldOut
-                          ? 'border-gray-200 bg-gray-50 opacity-75 cursor-not-allowed'
+                          ? 'bg-gray-50 ring-gray-100 opacity-75 cursor-not-allowed'
                           : isSelected
-                            ? 'border-msq-purple-rich ring-1 ring-msq-purple-rich/30'
-                            : 'border-gray-200 hover:border-gray-300'
+                            ? 'bg-white ring-msq-purple-rich/40'
+                            : 'bg-gray-50/70 ring-gray-100 hover:bg-white hover:ring-gray-200'
                       }`}
                     >
                       <input
@@ -264,11 +267,11 @@ const EventTicketCheckout = ({ event }) => {
                   max={maxQuantity}
                   value={quantity}
                   onChange={handleQuantityChange}
-                  className="w-24 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-msq-purple-rich/30"
+                  className={`${inputClass} w-24`}
                 />
               </div>
 
-              <div className="rounded-md bg-gray-50 border border-gray-200 px-3 py-2 text-sm">
+              <div className="rounded-md bg-gray-50 px-3 py-2 text-sm shadow-sm ring-1 ring-gray-100">
                 <span className="text-gray-600">Total: </span>
                 <span className="font-semibold text-gray-900">
                   {formatCurrency(pesewasToGhs(lineTotalPesewas))}

--- a/src/components/events/EventVolunteerPanel.jsx
+++ b/src/components/events/EventVolunteerPanel.jsx
@@ -7,6 +7,8 @@ import { validateEventForm } from '../../utils/events/validateEventForm';
 import Button from '../ui/Button';
 import DynamicEventForm from './DynamicEventForm';
 
+const panelClass = 'rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100 sm:p-6';
+
 const buildInitialApplicantInfo = (formSchema, currentUser) => {
   const applicantInfo = {};
   const fields = formSchema?.builtinFields || [];
@@ -132,7 +134,7 @@ const EventVolunteerPanel = ({ event }) => {
 
   if (!volunteerForm) {
     return (
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className={panelClass}>
         <h2 className="text-lg font-semibold text-gray-900 mb-2">Volunteer</h2>
         <p className="text-sm text-gray-500">
           Volunteer applications are not available for this event.
@@ -143,7 +145,7 @@ const EventVolunteerPanel = ({ event }) => {
 
   if (submittedSummary) {
     return (
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className={panelClass}>
         <h2 className="text-lg font-semibold text-gray-900 mb-2">Volunteer</h2>
         <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
           <p className="font-medium mb-1">Thank you for applying!</p>
@@ -173,7 +175,7 @@ const EventVolunteerPanel = ({ event }) => {
   }
 
   return (
-    <section className="bg-white rounded-lg border border-gray-200 p-6">
+    <section className={panelClass}>
       <h2 className="text-lg font-semibold text-gray-900 mb-2">Volunteer</h2>
       <p className="text-sm text-gray-600 mb-4">
         Interested in helping out? Fill in the form below to apply as a volunteer.

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -84,6 +84,17 @@ const EventDetails = () => {
       />
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
         <div className="mx-auto max-w-5xl space-y-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <div className="mb-3 flex justify-center">
+              <span
+                className={`inline-flex px-2.5 py-1 text-xs font-medium rounded-full ${getEventTypeColor(event.type)}`}
+              >
+                {EVENT_TYPE_LABELS[event.type] || event.type}
+              </span>
+            </div>
+            <h1 className="text-3xl sm:text-4xl font-bebas text-msq-purple-rich">{event.name}</h1>
+          </div>
+
           {event.banner?.url && (
             <img
               src={event.banner.url}
@@ -93,57 +104,56 @@ const EventDetails = () => {
           )}
 
           <div className="space-y-6">
-            <div className="flex flex-wrap items-center gap-3">
-              <h1 className="text-2xl sm:text-3xl font-bebas text-msq-purple-rich">{event.name}</h1>
-              <span
-                className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventTypeColor(event.type)}`}
-              >
-                {EVENT_TYPE_LABELS[event.type] || event.type}
-              </span>
-            </div>
+            <div
+              className={`grid justify-items-center gap-4 text-center text-sm text-gray-700 sm:items-center sm:text-left ${
+                venueLabel ? 'sm:grid-cols-2' : ''
+              }`}
+            >
+              <div className="space-y-3">
+                <p className="flex items-start justify-center gap-2 sm:justify-start">
+                  <Calendar className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
+                  <span>{formatEventDate(event.eventDate)}</span>
+                </p>
+                {spotsLabel && (
+                  <p className="flex items-center justify-center gap-2 font-medium text-msq-purple-deep sm:justify-start">
+                    <Users className="w-4 h-4 shrink-0" aria-hidden="true" />
+                    <span>{spotsLabel}</span>
+                  </p>
+                )}
+              </div>
 
-            <div className="space-y-2 text-sm text-gray-700">
-              <p className="flex items-start gap-2">
-                <Calendar className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
-                <span>{formatEventDate(event.eventDate)}</span>
-              </p>
               {venueLabel && (
-                <p className="flex items-start gap-2">
+                <p className="flex items-start justify-center gap-2 sm:justify-self-end">
                   <MapPin className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
                   <span>
-                    {venueLabel}
+                    <span className="block">{venueLabel}</span>
                     {venueLink && (
-                      <>
-                        {' · '}
-                        <a
-                          href={venueLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-msq-purple-rich hover:underline"
-                        >
-                          View location
-                        </a>
-                      </>
+                      <a
+                        href={venueLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-1 block text-msq-purple-rich hover:underline"
+                      >
+                        View location
+                      </a>
                     )}
                   </span>
-                </p>
-              )}
-              {spotsLabel && (
-                <p className="flex items-center gap-2 font-medium text-msq-purple-deep">
-                  <Users className="w-4 h-4 shrink-0" aria-hidden="true" />
-                  <span>{spotsLabel}</span>
                 </p>
               )}
             </div>
 
             {event.description && (
-              <section className="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100 sm:p-6">
-                <h2 className="text-lg font-semibold text-gray-900 mb-4">About this event</h2>
-                <div
-                  className="prose prose-sm max-w-none text-gray-700"
-                  dangerouslySetInnerHTML={{ __html: event.description }}
-                />
-              </section>
+              <div className="space-y-3">
+                <h2 className="text-lg font-semibold text-gray-700">About this event</h2>
+                <section className="rounded-xl bg-msq-purple-rich/5 px-5 py-5 sm:px-6">
+                  <div className="border-l-2 border-msq-purple-rich/30 pl-4">
+                    <div
+                      className="prose prose-sm max-w-3xl text-gray-700 prose-p:leading-relaxed prose-strong:text-gray-900 prose-a:text-msq-purple-rich prose-a:underline"
+                      dangerouslySetInnerHTML={{ __html: event.description }}
+                    />
+                  </div>
+                </section>
+              </div>
             )}
           </div>
 

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -83,74 +83,61 @@ const EventDetails = () => {
         type="article"
       />
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
-        <Link
-          to="/events"
-          className="inline-block mb-6 text-sm text-msq-purple-rich hover:underline"
-        >
-          ← Back to events
-        </Link>
-
-        {event.banner?.url && (
-          <div className="mb-6">
+        <div className="mx-auto max-w-5xl space-y-8">
+          {event.banner?.url && (
             <img
               src={event.banner.url}
               alt={event.name}
-              className="w-full max-h-80 object-cover rounded-lg border border-gray-200"
+              className="max-h-80 w-full rounded-xl object-cover shadow-sm"
             />
-          </div>
-        )}
+          )}
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-2 space-y-6">
-            <div>
-              <div className="flex flex-wrap items-center gap-3 mb-2">
-                <h1 className="text-2xl sm:text-3xl font-bebas text-msq-purple-rich">
-                  {event.name}
-                </h1>
-                <span
-                  className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventTypeColor(event.type)}`}
-                >
-                  {EVENT_TYPE_LABELS[event.type] || event.type}
-                </span>
-              </div>
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl sm:text-3xl font-bebas text-msq-purple-rich">{event.name}</h1>
+              <span
+                className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getEventTypeColor(event.type)}`}
+              >
+                {EVENT_TYPE_LABELS[event.type] || event.type}
+              </span>
+            </div>
 
-              <div className="space-y-2 text-sm text-gray-700">
+            <div className="space-y-2 text-sm text-gray-700">
+              <p className="flex items-start gap-2">
+                <Calendar className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>{formatEventDate(event.eventDate)}</span>
+              </p>
+              {venueLabel && (
                 <p className="flex items-start gap-2">
-                  <Calendar className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
-                  <span>{formatEventDate(event.eventDate)}</span>
+                  <MapPin className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
+                  <span>
+                    {venueLabel}
+                    {venueLink && (
+                      <>
+                        {' · '}
+                        <a
+                          href={venueLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-msq-purple-rich hover:underline"
+                        >
+                          View location
+                        </a>
+                      </>
+                    )}
+                  </span>
                 </p>
-                {venueLabel && (
-                  <p className="flex items-start gap-2">
-                    <MapPin className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
-                    <span>
-                      {venueLabel}
-                      {venueLink && (
-                        <>
-                          {' · '}
-                          <a
-                            href={venueLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-msq-purple-rich hover:underline"
-                          >
-                            View location
-                          </a>
-                        </>
-                      )}
-                    </span>
-                  </p>
-                )}
-                {spotsLabel && (
-                  <p className="flex items-center gap-2 font-medium text-msq-purple-deep">
-                    <Users className="w-4 h-4 shrink-0" aria-hidden="true" />
-                    <span>{spotsLabel}</span>
-                  </p>
-                )}
-              </div>
+              )}
+              {spotsLabel && (
+                <p className="flex items-center gap-2 font-medium text-msq-purple-deep">
+                  <Users className="w-4 h-4 shrink-0" aria-hidden="true" />
+                  <span>{spotsLabel}</span>
+                </p>
+              )}
             </div>
 
             {event.description && (
-              <section className="bg-white rounded-lg border border-gray-200 p-6">
+              <section className="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100 sm:p-6">
                 <h2 className="text-lg font-semibold text-gray-900 mb-4">About this event</h2>
                 <div
                   className="prose prose-sm max-w-none text-gray-700"
@@ -160,7 +147,7 @@ const EventDetails = () => {
             )}
           </div>
 
-          <aside className="space-y-6">
+          <div className="space-y-6">
             {isFree && (
               <EventRegistrationPanel
                 event={event}
@@ -187,7 +174,7 @@ const EventDetails = () => {
             {isPaid && <EventTicketCheckout event={event} />}
 
             {hasVolunteerForm && <EventVolunteerPanel event={event} />}
-          </aside>
+          </div>
         </div>
       </main>
     </>

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -66,27 +66,25 @@ const Events = () => {
           </p>
         </div>
 
-        <div className="mb-6 p-4 bg-white rounded-lg border border-gray-200">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <input
-              type="search"
-              placeholder="Search events"
-              value={q}
-              onChange={e => setQ(e.target.value)}
-              className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich focus:border-msq-purple-rich"
-            />
-            <select
-              value={type}
-              onChange={e => setType(e.target.value)}
-              className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich focus:border-msq-purple-rich"
-            >
-              {TYPE_OPTIONS.map(o => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </div>
+        <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <input
+            type="search"
+            placeholder="Search events"
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-100 outline-none transition focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30"
+          />
+          <select
+            value={type}
+            onChange={e => setType(e.target.value)}
+            className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-100 outline-none transition focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30"
+          >
+            {TYPE_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
         </div>
 
         {isGridLoading ? (

--- a/src/pages/admin/AdminEventAttendees.jsx
+++ b/src/pages/admin/AdminEventAttendees.jsx
@@ -186,7 +186,6 @@ const AdminEventAttendees = () => {
     <AdminEventDetailLayout
       event={event}
       eventId={id}
-      onBack={() => navigate('/admin/events')}
       onEdit={() => navigate(`/admin/events/${id}/edit`)}
       canPublish={event.status === EVENT_STATUS.DRAFT}
       canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}

--- a/src/pages/admin/AdminEventDetail.jsx
+++ b/src/pages/admin/AdminEventDetail.jsx
@@ -99,7 +99,7 @@ const AdminEventDetail = () => {
           </div>
         )}
 
-        <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 p-6">
+        <div className="lg:col-span-3 bg-white rounded-lg border border-gray-200 p-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4">Details</h2>
           <div
             className="prose prose-sm max-w-none text-gray-700 mb-6"
@@ -156,19 +156,6 @@ const AdminEventDetail = () => {
               </div>
             )}
           </dl>
-        </div>
-
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Manage</h2>
-          <ul className="space-y-2 text-sm text-gray-600">
-            {event.type === EVENT_TYPE.PAID && (
-              <li>
-                Ticket types: {ticketTypes.length} configured
-                {hasActiveTickets ? ' (active tickets available)' : ' (none active yet)'}
-              </li>
-            )}
-            <li>Use the tabs above to manage tickets, forms, attendees, and volunteers.</li>
-          </ul>
         </div>
       </div>
     </AdminEventDetailLayout>

--- a/src/pages/admin/AdminEventDetail.jsx
+++ b/src/pages/admin/AdminEventDetail.jsx
@@ -79,7 +79,6 @@ const AdminEventDetail = () => {
     <AdminEventDetailLayout
       event={event}
       eventId={id}
-      onBack={() => navigate('/admin/events')}
       onEdit={() => navigate(`/admin/events/${id}/edit`)}
       canPublish={event.status === EVENT_STATUS.DRAFT}
       canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}

--- a/src/pages/admin/AdminEventRegistrationForm.jsx
+++ b/src/pages/admin/AdminEventRegistrationForm.jsx
@@ -35,6 +35,8 @@ const AdminEventRegistrationForm = () => {
   const formLoadError = formIsError
     ? formError?.response?.data?.error || formError?.message || 'Failed to load registration form'
     : null;
+  const formSchema = formData?.data ?? null;
+  const isFormConfigured = formSchema != null;
 
   const ticketTypes = event?.ticketTypes || [];
   const hasActiveTickets = ticketTypes.some(t => t.isActive);
@@ -95,7 +97,8 @@ const AdminEventRegistrationForm = () => {
         title="Registration form"
         description="Configure the fields guests fill out when registering for this event."
         identityKey="guestInfo"
-        initialSchema={formData?.data}
+        initialSchema={formSchema}
+        isConfigured={isFormConfigured}
         isLoading={formLoading}
         loadError={formLoadError}
         isSaving={upsertForm.isPending}

--- a/src/pages/admin/AdminEventRegistrationForm.jsx
+++ b/src/pages/admin/AdminEventRegistrationForm.jsx
@@ -82,7 +82,6 @@ const AdminEventRegistrationForm = () => {
     <AdminEventDetailLayout
       event={event}
       eventId={id}
-      onBack={() => navigate('/admin/events')}
       onEdit={() => navigate(`/admin/events/${id}/edit`)}
       canPublish={event.status === EVENT_STATUS.DRAFT}
       canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}

--- a/src/pages/admin/AdminEventTickets.jsx
+++ b/src/pages/admin/AdminEventTickets.jsx
@@ -81,7 +81,6 @@ const AdminEventTickets = () => {
     <AdminEventDetailLayout
       event={event}
       eventId={id}
-      onBack={() => navigate('/admin/events')}
       onEdit={() => navigate(`/admin/events/${id}/edit`)}
       canPublish={event.status === EVENT_STATUS.DRAFT}
       canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}

--- a/src/pages/admin/AdminEventVolunteerForm.jsx
+++ b/src/pages/admin/AdminEventVolunteerForm.jsx
@@ -35,6 +35,8 @@ const AdminEventVolunteerForm = () => {
   const formLoadError = formIsError
     ? formError?.response?.data?.error || formError?.message || 'Failed to load volunteer form'
     : null;
+  const formSchema = formData?.data ?? null;
+  const isFormConfigured = formSchema != null;
 
   const ticketTypes = event?.ticketTypes || [];
   const hasActiveTickets = ticketTypes.some(t => t.isActive);
@@ -95,7 +97,8 @@ const AdminEventVolunteerForm = () => {
         title="Volunteer form"
         description="Configure the fields applicants fill out when applying to volunteer."
         identityKey="applicantInfo"
-        initialSchema={formData?.data}
+        initialSchema={formSchema}
+        isConfigured={isFormConfigured}
         isLoading={formLoading}
         loadError={formLoadError}
         isSaving={upsertForm.isPending}

--- a/src/pages/admin/AdminEventVolunteerForm.jsx
+++ b/src/pages/admin/AdminEventVolunteerForm.jsx
@@ -82,7 +82,6 @@ const AdminEventVolunteerForm = () => {
     <AdminEventDetailLayout
       event={event}
       eventId={id}
-      onBack={() => navigate('/admin/events')}
       onEdit={() => navigate(`/admin/events/${id}/edit`)}
       canPublish={event.status === EVENT_STATUS.DRAFT}
       canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}

--- a/src/pages/admin/AdminEventVolunteers.jsx
+++ b/src/pages/admin/AdminEventVolunteers.jsx
@@ -150,7 +150,6 @@ const AdminEventVolunteers = () => {
     <AdminEventDetailLayout
       event={event}
       eventId={id}
-      onBack={() => navigate('/admin/events')}
       onEdit={() => navigate(`/admin/events/${id}/edit`)}
       canPublish={event.status === EVENT_STATUS.DRAFT}
       canCancel={event.status === EVENT_STATUS.DRAFT || event.status === EVENT_STATUS.PUBLISHED}

--- a/src/pages/admin/AdminEvents.jsx
+++ b/src/pages/admin/AdminEvents.jsx
@@ -29,16 +29,14 @@ const AdminEvents = () => {
   const navigate = useNavigate();
   const [page, setPage] = useState(1);
   const [limit] = useState(10);
-  const [q, setQ] = useState('');
   const [status, setStatus] = useState('');
   const [type, setType] = useState('');
 
   useEffect(() => {
     setPage(1);
-  }, [q, status, type]);
+  }, [status, type]);
 
   const params = { page, limit };
-  if (q.trim()) params.q = q.trim();
   if (status) params.status = status;
   if (type) params.type = type;
 
@@ -108,19 +106,12 @@ const AdminEvents = () => {
         onAction={() => navigate('/admin/events/new')}
       />
 
-      <div className="mb-4 p-4 bg-white rounded-lg border border-gray-200">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-          <input
-            type="search"
-            placeholder="Search events"
-            value={q}
-            onChange={e => setQ(e.target.value)}
-            className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich focus:border-msq-purple-rich"
-          />
+      <div className="mb-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <select
             value={status}
             onChange={e => setStatus(e.target.value)}
-            className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich"
+            className="px-3 py-2 rounded-md text-sm bg-white shadow-sm cursor-pointer focus:outline-none focus:ring-2 focus:ring-msq-purple-rich"
           >
             {STATUS_OPTIONS.map(o => (
               <option key={o.value} value={o.value}>
@@ -131,7 +122,7 @@ const AdminEvents = () => {
           <select
             value={type}
             onChange={e => setType(e.target.value)}
-            className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-msq-purple-rich"
+            className="px-3 py-2 rounded-md text-sm bg-white shadow-sm cursor-pointer focus:outline-none focus:ring-2 focus:ring-msq-purple-rich"
           >
             {TYPE_OPTIONS.map(o => (
               <option key={o.value} value={o.value}>


### PR DESCRIPTION
Refine the admin and public event UI to reduce visual noise, improve form editing, and make event listing/detail pages feel cleaner and easier to scan. This keeps the existing event data model and flows intact while updating presentation and editor ergonomics.

- Add a row-based custom question dropdown options editor with add, remove, and reorder controls
- Simplify admin event form builder and event overview UI by removing redundant helper copy and static panels
- Restyle public event detail, registration, ticket, volunteer, listing, and event card surfaces for a cleaner visual hierarchy