### PR TITLE
Improve event listing navigation, detail display, and rich-text description spacing

### DIFF
--- a/src/components/admin/RichTextEditor.jsx
+++ b/src/components/admin/RichTextEditor.jsx
@@ -3,7 +3,7 @@ import StarterKit from '@tiptap/starter-kit';
 import { sanitizeHTML } from '../../utils/sanitization';
 import { useEffect } from 'react';
 
-const RichTextEditor = ({ value, onChange, error }) => {
+const RichTextEditor = ({ value, onChange, error, placeholder = 'Enter description...' }) => {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -16,7 +16,7 @@ const RichTextEditor = ({ value, onChange, error }) => {
     editorProps: {
       attributes: {
         class: 'focus:outline-none min-h-[200px] px-4 py-3 text-base leading-relaxed text-gray-900',
-        'data-placeholder': 'Enter product description...',
+        'data-placeholder': placeholder,
       },
     },
     onUpdate: ({ editor }) => {
@@ -72,6 +72,14 @@ const RichTextEditor = ({ value, onChange, error }) => {
           title="Italic"
         >
           <em>I</em>
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().setHardBreak().run()}
+          className="px-3 py-1.5 rounded text-sm font-semibold transition-colors bg-white text-gray-700 hover:bg-gray-100"
+          title="Line break (Shift+Enter)"
+        >
+          ↵
         </button>
         <button
           type="button"

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { Link } from 'react-router';
-import { Calendar, MapPin, Users } from 'lucide-react';
+import { ArrowUpRight, Calendar, MapPin, Users } from 'lucide-react';
 
 import { EVENT_TYPE_LABELS } from '../../constants/events';
 import { formatEventDate, formatEventVenue } from '../../utils/events';
@@ -61,6 +61,14 @@ const EventCard = ({ event }) => {
             <span>{spotsLabel}</span>
           </p>
         )}
+        <Link
+          to={`/events/${event.slug}`}
+          className="mt-3 inline-flex items-center justify-center gap-1 whitespace-nowrap text-xs sm:text-sm font-medium text-black hover:text-msq-purple-rich transition-colors"
+          aria-label={`View ${event.name}`}
+        >
+          View
+          <ArrowUpRight className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+        </Link>
       </div>
     </div>
   );

--- a/src/components/products/ProductInfo.jsx
+++ b/src/components/products/ProductInfo.jsx
@@ -31,7 +31,7 @@ function ProductInfo({ product, price = product?.price, section = 'all' }) {
         <>
           <h2 className="text-lg sm:text-xl lg:text-2xl text-gray-900">Details</h2>
           <div
-            className="text-sm md:text-base leading-snug md:leading-normal product-description text-gray-900"
+            className="text-sm md:text-base leading-snug md:leading-normal rich-text-content text-gray-900"
             dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
           />
         </>

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,10 @@ body,
   font-style: italic;
 }
 
+.ProseMirror br {
+  line-height: 1.6;
+}
+
 /* Rich Text Content Rendering Styles */
 .rich-text-content p {
   margin: 0.75rem 0;

--- a/src/index.css
+++ b/src/index.css
@@ -109,49 +109,49 @@ body,
   font-style: italic;
 }
 
-/* Product Description Rendering Styles */
-.product-description p {
+/* Rich Text Content Rendering Styles */
+.rich-text-content p {
   margin: 0.75rem 0;
   line-height: 1.6;
 }
 
-.product-description p:first-child {
+.rich-text-content p:first-child {
   margin-top: 0;
 }
 
-.product-description p:last-child {
+.rich-text-content p:last-child {
   margin-bottom: 0;
 }
 
-.product-description br {
+.rich-text-content br {
   line-height: 1.6;
 }
 
-.product-description h1,
-.product-description h2,
-.product-description h3 {
+.rich-text-content h1,
+.rich-text-content h2,
+.rich-text-content h3 {
   font-weight: bold;
   margin: 1rem 0 0.5rem 0;
 }
 
-.product-description h1 {
+.rich-text-content h1 {
   font-size: 1.5rem;
 }
 
-.product-description h2 {
+.rich-text-content h2 {
   font-size: 1.25rem;
 }
 
-.product-description h3 {
+.rich-text-content h3 {
   font-size: 1.125rem;
 }
 
-.product-description ul,
-.product-description ol {
+.rich-text-content ul,
+.rich-text-content ol {
   margin: 0.75rem 0;
   padding-left: 1.5rem;
 }
 
-.product-description li {
+.rich-text-content li {
   margin: 0.25rem 0;
 }

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -99,7 +99,7 @@ const EventDetails = () => {
             <img
               src={event.banner.url}
               alt={event.name}
-              className="max-h-80 w-full rounded-xl object-cover shadow-sm"
+              className="block w-full h-auto rounded-xl shadow-sm"
             />
           )}
 

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -148,7 +148,7 @@ const EventDetails = () => {
                 <section className="rounded-xl bg-msq-purple-rich/5 px-5 py-5 sm:px-6">
                   <div className="border-l-2 border-msq-purple-rich/30 pl-4">
                     <div
-                      className="prose prose-sm max-w-3xl text-gray-700 prose-p:leading-relaxed prose-strong:text-gray-900 prose-a:text-msq-purple-rich prose-a:underline"
+                      className="rich-text-content max-w-3xl text-gray-700 [&_a]:text-msq-purple-rich [&_a]:underline [&_strong]:text-gray-900"
                       dangerouslySetInnerHTML={{ __html: event.description }}
                     />
                   </div>

--- a/src/pages/admin/AdminEventDetail.jsx
+++ b/src/pages/admin/AdminEventDetail.jsx
@@ -102,7 +102,7 @@ const AdminEventDetail = () => {
         <div className="lg:col-span-3 bg-white rounded-lg border border-gray-200 p-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4">Details</h2>
           <div
-            className="prose prose-sm max-w-none text-gray-700 mb-6"
+            className="rich-text-content max-w-none text-gray-700 mb-6"
             dangerouslySetInnerHTML={{ __html: event.description }}
           />
           <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">


### PR DESCRIPTION
This branch polishes the public events experience and closes a formatting gap between product and event descriptions. Event cards now include an explicit View action after registrant feedback that the listing page was unclear. Portrait flyers render in full on the detail page, and event descriptions use the same rich-text spacing as products. The shared admin TipTap editor also gains a line-break control and configurable placeholder text.

- Add View link with arrow icon to event cards on the listing page
- Show full portrait event banners on the detail page using natural aspect ratio instead of cropped object-cover
- Rename product-description styles to shared rich-text-content for reusable rich-text rendering
- Apply rich-text-content spacing to public and admin event description views
- Add line break toolbar button to the shared rich text editor
- Support per-form placeholder text and improved br spacing while editing