### PR TITLE
Close event signup UI after the event and polish the events filter bar

### DIFF
--- a/src/api/events.js
+++ b/src/api/events.js
@@ -14,8 +14,8 @@ const buildQueryString = params => {
 };
 
 /**
- * GET /events?page&limit&type&q
- * @param {Object} params - page, limit, type (free|paid), q
+ * GET /events?page&limit&type&q&when
+ * @param {Object} params - page, limit, type (free|paid), q, when (upcoming|past|all)
  * @returns {Promise<{ success, data: event[], pagination }>}
  */
 export const getPublishedEvents = async (params = {}) => {

--- a/src/components/events/EventRegistrationPanel.jsx
+++ b/src/components/events/EventRegistrationPanel.jsx
@@ -3,7 +3,11 @@ import { useMemo, useState } from 'react';
 import { createGuestSession } from '../../api/auth';
 import { useAuthState } from '../../contexts/auth/useAuth';
 import { useRegisterForEvent } from '../../hooks/mutations/useEventMutations';
-import { validateEventForm } from '../../utils/events/validateEventForm';
+import {
+  isEventRegistrationOpen,
+  REGISTRATION_CLOSED_MESSAGE,
+  validateEventForm,
+} from '../../utils/events';
 import Button from '../ui/Button';
 import DynamicEventForm from './DynamicEventForm';
 
@@ -44,6 +48,7 @@ const EventRegistrationPanel = ({ event, onSuccess }) => {
   const registerMutation = useRegisterForEvent();
 
   const registrationForm = event.registrationForm;
+  const isClosed = !isEventRegistrationOpen(event);
   const isFull = event.spotsRemaining === 0;
 
   const [values, setValues] = useState(() => ({
@@ -149,7 +154,9 @@ const EventRegistrationPanel = ({ event, onSuccess }) => {
         Reserve your spot for this free event. Fill in the details below to register.
       </p>
 
-      {isFull ? (
+      {isClosed ? (
+        <p className="text-sm font-medium text-gray-600">{REGISTRATION_CLOSED_MESSAGE}.</p>
+      ) : isFull ? (
         <p className="text-sm font-medium text-red-600">This event is full — no spots remaining.</p>
       ) : (
         <form onSubmit={handleSubmit} className="space-y-4" noValidate>

--- a/src/components/events/EventTicketCheckout.jsx
+++ b/src/components/events/EventTicketCheckout.jsx
@@ -4,7 +4,12 @@ import { createGuestSession } from '../../api/auth';
 import { useAuthState } from '../../contexts/auth/useAuth';
 import { useCheckoutEvent } from '../../hooks/mutations/useEventMutations';
 import { formatCurrency } from '../../utils/admin/tableHelpers';
-import { pesewasToGhs, validateEventForm } from '../../utils/events';
+import {
+  isEventRegistrationOpen,
+  pesewasToGhs,
+  REGISTRATION_CLOSED_MESSAGE,
+  validateEventForm,
+} from '../../utils/events';
 import Button from '../ui/Button';
 import DynamicEventForm from './DynamicEventForm';
 
@@ -47,6 +52,7 @@ const EventTicketCheckout = ({ event }) => {
   const checkoutMutation = useCheckoutEvent();
 
   const registrationForm = event.registrationForm;
+  const isClosed = !isEventRegistrationOpen(event);
   const activeTickets = useMemo(
     () => (event.ticketTypes || []).filter(t => t.isActive),
     [event.ticketTypes]
@@ -197,7 +203,9 @@ const EventTicketCheckout = ({ event }) => {
         Select a ticket type and complete the registration form to proceed to payment.
       </p>
 
-      {eventFull ? (
+      {isClosed ? (
+        <p className="text-sm font-medium text-gray-600">{REGISTRATION_CLOSED_MESSAGE}.</p>
+      ) : eventFull ? (
         <p className="text-sm font-medium text-red-600">This event is full — no spots remaining.</p>
       ) : (
         <form onSubmit={handleSubmit} className="space-y-5" noValidate>

--- a/src/components/events/EventTypeFilterDropdown.jsx
+++ b/src/components/events/EventTypeFilterDropdown.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Triangle, Wallet } from 'lucide-react';
+
+import { EVENT_TYPE_LABELS, EVENT_TYPES } from '../../constants/events';
+
+const MotionDiv = motion.div;
+
+const TYPE_OPTIONS = [
+  { value: '', label: 'All types' },
+  ...EVENT_TYPES.map(value => ({ value, label: EVENT_TYPE_LABELS[value] })),
+];
+
+/**
+ * Pill-styled event type filter dropdown (Free / Paid / All types).
+ *
+ * @param {Object} props
+ * @param {string} props.value - '' | 'free' | 'paid'
+ * @param {(next: string) => void} props.onChange
+ * @param {string} [props.className]
+ */
+const EventTypeFilterDropdown = ({ value = '', onChange, className = '' }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+  const triggerRef = useRef(null);
+
+  const selectedOption = TYPE_OPTIONS.find(option => option.value === value) || TYPE_OPTIONS[0];
+  const hasActiveFilter = Boolean(value);
+
+  useEffect(() => {
+    const handleClickOutside = event => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleKeyDown = e => {
+    if (e.key === 'Escape') {
+      setIsOpen(false);
+      triggerRef.current?.focus();
+    }
+  };
+
+  const handleSelect = nextValue => {
+    onChange?.(nextValue);
+    setIsOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setIsOpen(open => !open)}
+        onKeyDown={handleKeyDown}
+        className={`inline-flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium shadow-sm ring-1 transition ${
+          hasActiveFilter || isOpen
+            ? 'bg-msq-purple-rich text-white ring-msq-purple-rich'
+            : 'bg-gray-50 text-gray-700 ring-gray-100 hover:bg-white hover:ring-gray-200'
+        }`}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label={`Filter events by type, currently ${selectedOption.label}`}
+      >
+        <Wallet className="h-4 w-4 shrink-0" aria-hidden="true" />
+        <span>{selectedOption.label}</span>
+        <Triangle
+          className={`fill-current stroke-none transition-transform duration-200 ${
+            isOpen ? 'rotate-0' : 'rotate-180'
+          }`}
+          size={10}
+          aria-hidden="true"
+        />
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <MotionDiv
+            className="absolute left-0 z-40 mt-1 min-w-full rounded-md bg-white py-1 shadow-xl shadow-black/10 ring-1 ring-gray-100"
+            initial={{ opacity: 0, y: -6, scaleY: 0.96 }}
+            animate={{ opacity: 1, y: 0, scaleY: 1 }}
+            exit={{ opacity: 0, y: -6, scaleY: 0.96 }}
+            transition={{ duration: 0.18, ease: 'easeOut' }}
+            style={{ transformOrigin: 'top' }}
+            role="listbox"
+            aria-label="Event type options"
+          >
+            {TYPE_OPTIONS.map(option => {
+              const isSelected = option.value === value;
+              return (
+                <button
+                  key={option.value || 'all'}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => handleSelect(option.value)}
+                  className={`w-full cursor-pointer whitespace-nowrap px-4 py-2 text-left text-sm transition-colors duration-200 ${
+                    isSelected
+                      ? 'bg-msq-gold-light/20 font-medium text-msq-purple-deep'
+                      : 'text-msq-purple-deep hover:bg-msq-gold-light/10 hover:text-msq-purple-rich'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </MotionDiv>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default EventTypeFilterDropdown;

--- a/src/components/events/EventVolunteerPanel.jsx
+++ b/src/components/events/EventVolunteerPanel.jsx
@@ -3,7 +3,11 @@ import { useMemo, useState } from 'react';
 import { createGuestSession } from '../../api/auth';
 import { useAuthState } from '../../contexts/auth/useAuth';
 import { useSubmitVolunteerApplication } from '../../hooks/mutations/useEventMutations';
-import { validateEventForm } from '../../utils/events/validateEventForm';
+import {
+  isEventRegistrationOpen,
+  REGISTRATION_CLOSED_MESSAGE,
+  validateEventForm,
+} from '../../utils/events';
 import Button from '../ui/Button';
 import DynamicEventForm from './DynamicEventForm';
 
@@ -43,6 +47,7 @@ const EventVolunteerPanel = ({ event }) => {
   const volunteerMutation = useSubmitVolunteerApplication();
 
   const volunteerForm = event.volunteerForm;
+  const isClosed = !isEventRegistrationOpen(event);
 
   const [values, setValues] = useState(() => ({
     applicantInfo: buildInitialApplicantInfo(volunteerForm, currentUser),
@@ -181,32 +186,36 @@ const EventVolunteerPanel = ({ event }) => {
         Interested in helping out? Fill in the form below to apply as a volunteer.
       </p>
 
-      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
-        <DynamicEventForm
-          formSchema={volunteerForm}
-          identityKey="applicantInfo"
-          values={values}
-          errors={errors}
-          readOnly={false}
-          onIdentityFieldChange={handleIdentityFieldChange}
-          onCustomAnswerChange={handleCustomAnswerChange}
-        />
+      {isClosed ? (
+        <p className="text-sm font-medium text-gray-600">{REGISTRATION_CLOSED_MESSAGE}.</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          <DynamicEventForm
+            formSchema={volunteerForm}
+            identityKey="applicantInfo"
+            values={values}
+            errors={errors}
+            readOnly={false}
+            onIdentityFieldChange={handleIdentityFieldChange}
+            onCustomAnswerChange={handleCustomAnswerChange}
+          />
 
-        {submitError && (
-          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-            {submitError}
-          </div>
-        )}
+          {submitError && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {submitError}
+            </div>
+          )}
 
-        <Button
-          type="submit"
-          variant="primary"
-          className="w-full px-4 py-3 text-sm"
-          disabled={volunteerMutation.isPending}
-        >
-          {volunteerMutation.isPending ? 'Submitting…' : 'Apply to volunteer'}
-        </Button>
-      </form>
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-full px-4 py-3 text-sm"
+            disabled={volunteerMutation.isPending}
+          >
+            {volunteerMutation.isPending ? 'Submitting…' : 'Apply to volunteer'}
+          </Button>
+        </form>
+      )}
     </section>
   );
 };

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -92,6 +92,21 @@ export const EVENT_WHEN_DESCRIPTIONS = {
   [EVENT_WHEN.ALL]: 'Browse every published Misqabbi event.',
 };
 
+export const EVENT_WHEN_EMPTY = {
+  [EVENT_WHEN.UPCOMING]: {
+    title: 'No upcoming events',
+    body: 'Check back soon for workshops, gatherings, and new experiences.',
+  },
+  [EVENT_WHEN.PAST]: {
+    title: 'No past events',
+    body: 'Past events will appear here after their date has passed.',
+  },
+  [EVENT_WHEN.ALL]: {
+    title: 'No events found',
+    body: 'There are no published events to show right now.',
+  },
+};
+
 export const REGISTRATION_STATUS_LABELS = {
   [REGISTRATION_STATUS.PENDING]: 'Pending',
   [REGISTRATION_STATUS.CONFIRMED]: 'Confirmed',

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -15,6 +15,15 @@ export const EVENT_TYPE = {
 
 export const EVENT_TYPES = Object.values(EVENT_TYPE);
 
+/** Public events list time window filter */
+export const EVENT_WHEN = {
+  UPCOMING: 'upcoming',
+  PAST: 'past',
+  ALL: 'all',
+};
+
+export const EVENT_WHENS = Object.values(EVENT_WHEN);
+
 /** Registration status after RSVP or checkout */
 export const REGISTRATION_STATUS = {
   PENDING: 'pending',
@@ -62,6 +71,25 @@ export const EVENT_STATUS_LABELS = {
 export const EVENT_TYPE_LABELS = {
   [EVENT_TYPE.FREE]: 'Free',
   [EVENT_TYPE.PAID]: 'Paid',
+};
+
+export const EVENT_WHEN_LABELS = {
+  [EVENT_WHEN.UPCOMING]: 'Upcoming',
+  [EVENT_WHEN.PAST]: 'Past',
+  [EVENT_WHEN.ALL]: 'All',
+};
+
+export const EVENT_WHEN_HEADINGS = {
+  [EVENT_WHEN.UPCOMING]: 'Upcoming Events',
+  [EVENT_WHEN.PAST]: 'Past Events',
+  [EVENT_WHEN.ALL]: 'All Events',
+};
+
+export const EVENT_WHEN_DESCRIPTIONS = {
+  [EVENT_WHEN.UPCOMING]:
+    'Join us for workshops, gatherings, and experiences designed with you in mind.',
+  [EVENT_WHEN.PAST]: 'Browse events that have already taken place.',
+  [EVENT_WHEN.ALL]: 'Browse every published Misqabbi event.',
 };
 
 export const REGISTRATION_STATUS_LABELS = {

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -87,23 +87,25 @@ export const EVENT_WHEN_HEADINGS = {
 
 export const EVENT_WHEN_DESCRIPTIONS = {
   [EVENT_WHEN.UPCOMING]:
-    'Join us for workshops, gatherings, and experiences designed with you in mind.',
-  [EVENT_WHEN.PAST]: 'Browse events that have already taken place.',
-  [EVENT_WHEN.ALL]: 'Browse every published Misqabbi event.',
+    'Moments made for her, workshops, gatherings, and soft little experiences worth showing up for.',
+  [EVENT_WHEN.PAST]:
+    "A look back at the moments we've shared, the laughs, the looks, the girlies who showed up.",
+  [EVENT_WHEN.ALL]:
+    "Every Misqabbi moment in one place, what's coming and the ones we'll always remember.",
 };
 
 export const EVENT_WHEN_EMPTY = {
   [EVENT_WHEN.UPCOMING]: {
     title: 'No upcoming events',
-    body: 'Check back soon for workshops, gatherings, and new experiences.',
+    body: "We're preparing something special. Check back soon.",
   },
   [EVENT_WHEN.PAST]: {
-    title: 'No past events',
-    body: 'Past events will appear here after their date has passed.',
+    title: 'No past events yet',
+    body: 'Our first chapters are still being written.',
   },
   [EVENT_WHEN.ALL]: {
-    title: 'No events found',
-    body: 'There are no published events to show right now.',
+    title: 'Nothing to show just yet',
+    body: 'New Misqabbi moments are on the way.',
   },
 };
 

--- a/src/hooks/queries/useEvents.js
+++ b/src/hooks/queries/useEvents.js
@@ -3,7 +3,7 @@ import { getPublishedEvents, getEventBySlug } from '../../api/events';
 
 /**
  * Query hook for published events listing
- * @param {Object} params - page, limit, type, q
+ * @param {Object} params - page, limit, type, q, when
  */
 export const useEvents = (params = {}, options = {}) => {
   return useQuery({

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -12,6 +12,7 @@ import {
   EVENT_TYPES,
   EVENT_WHEN,
   EVENT_WHEN_DESCRIPTIONS,
+  EVENT_WHEN_EMPTY,
   EVENT_WHEN_HEADINGS,
   EVENT_WHEN_LABELS,
 } from '../constants/events';
@@ -53,6 +54,7 @@ const Events = () => {
   const isSearching = Boolean(q.trim() || type);
   const heading = EVENT_WHEN_HEADINGS[when] || EVENT_WHEN_HEADINGS[EVENT_WHEN.UPCOMING];
   const description = EVENT_WHEN_DESCRIPTIONS[when] || EVENT_WHEN_DESCRIPTIONS[EVENT_WHEN.UPCOMING];
+  const emptyCopy = EVENT_WHEN_EMPTY[when] || EVENT_WHEN_EMPTY[EVENT_WHEN.ALL];
   const errMsg = isError
     ? error?.response?.data?.error || error?.message || 'Failed to load events'
     : null;
@@ -145,11 +147,11 @@ const Events = () => {
           </div>
         ) : events.length === 0 ? (
           <div className="p-8 text-center border border-gray-200 rounded-lg bg-white">
-            <div className="text-lg font-medium text-gray-900">No events found</div>
+            <div className="text-lg font-medium text-gray-900">
+              {isSearching ? 'No events found' : emptyCopy.title}
+            </div>
             <p className="mt-2 text-sm text-gray-600">
-              {isSearching
-                ? 'Try adjusting your search or filters.'
-                : 'Check back soon for upcoming events.'}
+              {isSearching ? 'Try adjusting your search or filters.' : emptyCopy.body}
             </p>
           </div>
         ) : (

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -35,14 +35,12 @@ const Events = () => {
   const [page, setPage] = useState(1);
   const [type, setType] = useState('');
   const [when, setWhen] = useState(EVENT_WHEN.UPCOMING);
-  const [q, setQ] = useState('');
 
   useEffect(() => {
     setPage(1);
-  }, [q, type, when]);
+  }, [type, when]);
 
   const params = { page, limit: EVENTS_PER_PAGE, when };
-  if (q.trim()) params.q = q.trim();
   if (type) params.type = type;
 
   const { data, isLoading, isFetching, isError, error, refetch } = useEvents(params);
@@ -51,7 +49,7 @@ const Events = () => {
   const pagination = data?.pagination || {};
   const totalPages = pagination.totalPages || 1;
   const isGridLoading = isLoading || isFetching;
-  const isSearching = Boolean(q.trim() || type);
+  const isFiltered = Boolean(type);
   const heading = EVENT_WHEN_HEADINGS[when] || EVENT_WHEN_HEADINGS[EVENT_WHEN.UPCOMING];
   const description = EVENT_WHEN_DESCRIPTIONS[when] || EVENT_WHEN_DESCRIPTIONS[EVENT_WHEN.UPCOMING];
   const emptyCopy = EVENT_WHEN_EMPTY[when] || EVENT_WHEN_EMPTY[EVENT_WHEN.ALL];
@@ -79,46 +77,40 @@ const Events = () => {
           <p className="text-gray-600 mt-2">{description}</p>
         </div>
 
-        <div
-          className="mb-4 flex flex-wrap gap-2"
-          role="tablist"
-          aria-label="Filter events by time"
-        >
-          {WHEN_OPTIONS.map(option => {
-            const WhenIcon = option.icon;
-            const isActive = when === option.value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                onClick={() => setWhen(option.value)}
-                className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium shadow-sm ring-1 transition ${
-                  isActive
-                    ? 'bg-msq-purple-rich text-white ring-msq-purple-rich'
-                    : 'bg-gray-50 text-gray-700 ring-gray-100 hover:bg-white hover:ring-gray-200'
-                }`}
-              >
-                <WhenIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
-                <span>{EVENT_WHEN_LABELS[option.value]}</span>
-              </button>
-            );
-          })}
-        </div>
+        <div className="mb-6 flex flex-wrap items-center gap-2">
+          <div
+            className="flex flex-wrap items-center gap-2"
+            role="tablist"
+            aria-label="Filter events by time"
+          >
+            {WHEN_OPTIONS.map(option => {
+              const WhenIcon = option.icon;
+              const isActive = when === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setWhen(option.value)}
+                  className={`inline-flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium shadow-sm ring-1 transition ${
+                    isActive
+                      ? 'bg-msq-purple-rich text-white ring-msq-purple-rich'
+                      : 'bg-gray-50 text-gray-700 ring-gray-100 hover:bg-white hover:ring-gray-200'
+                  }`}
+                >
+                  <WhenIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span>{EVENT_WHEN_LABELS[option.value]}</span>
+                </button>
+              );
+            })}
+          </div>
 
-        <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <input
-            type="search"
-            placeholder="Search events"
-            value={q}
-            onChange={e => setQ(e.target.value)}
-            className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-100 outline-none transition focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30"
-          />
           <select
             value={type}
             onChange={e => setType(e.target.value)}
-            className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-900 shadow-sm ring-1 ring-gray-100 outline-none transition focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30"
+            aria-label="Filter events by type"
+            className="cursor-pointer rounded-md bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-gray-100 outline-none transition hover:bg-white hover:ring-gray-200 focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30"
           >
             {TYPE_OPTIONS.map(o => (
               <option key={o.value} value={o.value}>
@@ -139,7 +131,7 @@ const Events = () => {
               <button
                 type="button"
                 onClick={() => refetch()}
-                className="text-sm font-medium underline hover:opacity-80 shrink-0"
+                className="cursor-pointer text-sm font-medium underline hover:opacity-80 shrink-0"
               >
                 Retry
               </button>
@@ -148,19 +140,18 @@ const Events = () => {
         ) : events.length === 0 ? (
           <div className="p-8 text-center border border-gray-200 rounded-lg bg-white">
             <div className="text-lg font-medium text-gray-900">
-              {isSearching ? 'No events found' : emptyCopy.title}
+              {isFiltered ? 'No events found' : emptyCopy.title}
             </div>
             <p className="mt-2 text-sm text-gray-600">
-              {isSearching ? 'Try adjusting your search or filters.' : emptyCopy.body}
+              {isFiltered ? 'Try adjusting your filters.' : emptyCopy.body}
             </p>
           </div>
         ) : (
           <>
-            {isSearching && (
+            {isFiltered && (
               <div className="mb-4 text-center">
                 <p className="text-gray-600">
                   {events.length} result{events.length !== 1 ? 's' : ''} on this page
-                  {q.trim() && ` for "${q.trim()}"`}
                 </p>
               </div>
             )}

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Calendar, CalendarClock, CalendarDays } from 'lucide-react';
 
 import ProductGrid from '../components/products/ProductGrid';
 import EventCard from '../components/events/EventCard';
@@ -6,12 +7,25 @@ import PaginationLocal from '../components/orders/PaginationLocal';
 import SEO from '../components/SEO';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { useEvents } from '../hooks/queries/useEvents';
-import { EVENT_TYPES, EVENT_TYPE_LABELS } from '../constants/events';
+import {
+  EVENT_TYPE_LABELS,
+  EVENT_TYPES,
+  EVENT_WHEN,
+  EVENT_WHEN_DESCRIPTIONS,
+  EVENT_WHEN_HEADINGS,
+  EVENT_WHEN_LABELS,
+} from '../constants/events';
 import scrollToTop from '../utils/scrollToTop';
 
 const TYPE_OPTIONS = [
-  { value: '', label: 'All events' },
+  { value: '', label: 'All types' },
   ...EVENT_TYPES.map(value => ({ value, label: EVENT_TYPE_LABELS[value] })),
+];
+
+const WHEN_OPTIONS = [
+  { value: EVENT_WHEN.UPCOMING, icon: CalendarClock },
+  { value: EVENT_WHEN.PAST, icon: Calendar },
+  { value: EVENT_WHEN.ALL, icon: CalendarDays },
 ];
 
 const EVENTS_PER_PAGE = 12;
@@ -19,13 +33,14 @@ const EVENTS_PER_PAGE = 12;
 const Events = () => {
   const [page, setPage] = useState(1);
   const [type, setType] = useState('');
+  const [when, setWhen] = useState(EVENT_WHEN.UPCOMING);
   const [q, setQ] = useState('');
 
   useEffect(() => {
     setPage(1);
-  }, [q, type]);
+  }, [q, type, when]);
 
-  const params = { page, limit: EVENTS_PER_PAGE };
+  const params = { page, limit: EVENTS_PER_PAGE, when };
   if (q.trim()) params.q = q.trim();
   if (type) params.type = type;
 
@@ -36,6 +51,8 @@ const Events = () => {
   const totalPages = pagination.totalPages || 1;
   const isGridLoading = isLoading || isFetching;
   const isSearching = Boolean(q.trim() || type);
+  const heading = EVENT_WHEN_HEADINGS[when] || EVENT_WHEN_HEADINGS[EVENT_WHEN.UPCOMING];
+  const description = EVENT_WHEN_DESCRIPTIONS[when] || EVENT_WHEN_DESCRIPTIONS[EVENT_WHEN.UPCOMING];
   const errMsg = isError
     ? error?.response?.data?.error || error?.message || 'Failed to load events'
     : null;
@@ -53,17 +70,39 @@ const Events = () => {
 
   return (
     <>
-      <SEO
-        title="Events"
-        description="Discover upcoming Misqabbi events — workshops, meetups, and exclusive experiences."
-        canonicalPath="/events"
-      />
+      <SEO title={heading} description={description} canonicalPath="/events" />
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
         <div className="mb-6">
-          <h1 className="text-2xl font-bebas text-msq-purple-rich">Upcoming Events</h1>
-          <p className="text-gray-600 mt-2">
-            Join us for workshops, gatherings, and experiences designed with you in mind.
-          </p>
+          <h1 className="text-2xl font-bebas text-msq-purple-rich">{heading}</h1>
+          <p className="text-gray-600 mt-2">{description}</p>
+        </div>
+
+        <div
+          className="mb-4 flex flex-wrap gap-2"
+          role="tablist"
+          aria-label="Filter events by time"
+        >
+          {WHEN_OPTIONS.map(option => {
+            const WhenIcon = option.icon;
+            const isActive = when === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setWhen(option.value)}
+                className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium shadow-sm ring-1 transition ${
+                  isActive
+                    ? 'bg-msq-purple-rich text-white ring-msq-purple-rich'
+                    : 'bg-gray-50 text-gray-700 ring-gray-100 hover:bg-white hover:ring-gray-200'
+                }`}
+              >
+                <WhenIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span>{EVENT_WHEN_LABELS[option.value]}</span>
+              </button>
+            );
+          })}
         </div>
 
         <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -3,13 +3,12 @@ import { Calendar, CalendarClock, CalendarDays } from 'lucide-react';
 
 import ProductGrid from '../components/products/ProductGrid';
 import EventCard from '../components/events/EventCard';
+import EventTypeFilterDropdown from '../components/events/EventTypeFilterDropdown';
 import PaginationLocal from '../components/orders/PaginationLocal';
 import SEO from '../components/SEO';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { useEvents } from '../hooks/queries/useEvents';
 import {
-  EVENT_TYPE_LABELS,
-  EVENT_TYPES,
   EVENT_WHEN,
   EVENT_WHEN_DESCRIPTIONS,
   EVENT_WHEN_EMPTY,
@@ -17,11 +16,6 @@ import {
   EVENT_WHEN_LABELS,
 } from '../constants/events';
 import scrollToTop from '../utils/scrollToTop';
-
-const TYPE_OPTIONS = [
-  { value: '', label: 'All types' },
-  ...EVENT_TYPES.map(value => ({ value, label: EVENT_TYPE_LABELS[value] })),
-];
 
 const WHEN_OPTIONS = [
   { value: EVENT_WHEN.UPCOMING, icon: CalendarClock },
@@ -106,18 +100,7 @@ const Events = () => {
             })}
           </div>
 
-          <select
-            value={type}
-            onChange={e => setType(e.target.value)}
-            aria-label="Filter events by type"
-            className="cursor-pointer rounded-md bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-gray-100 outline-none transition hover:bg-white hover:ring-gray-200 focus:bg-white focus:ring-2 focus:ring-msq-purple-rich/30"
-          >
-            {TYPE_OPTIONS.map(o => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
+          <EventTypeFilterDropdown value={type} onChange={setType} />
         </div>
 
         {isGridLoading ? (

--- a/src/utils/events/index.js
+++ b/src/utils/events/index.js
@@ -12,3 +12,8 @@ export {
   getPaymentCallbackDestination,
   resolveEventCheckoutSlug,
 } from './paymentCallbackRouting';
+export {
+  isEventRegistrationOpen,
+  isPastEvent,
+  REGISTRATION_CLOSED_MESSAGE,
+} from './registrationWindow';

--- a/src/utils/events/registrationWindow.js
+++ b/src/utils/events/registrationWindow.js
@@ -1,0 +1,27 @@
+/**
+ * Client-side registration window helpers.
+ * Mirrors backend `eventRegistrationWindowLogic`: closed when now >= eventDate.
+ */
+
+export const REGISTRATION_CLOSED_MESSAGE = 'Registration for this event has closed';
+
+/**
+ * @param {{ eventDate?: string|Date }|null|undefined} event
+ * @param {Date} [now]
+ * @returns {boolean}
+ */
+export const isEventRegistrationOpen = (event, now = new Date()) => {
+  if (!event?.eventDate) return false;
+
+  const eventDate = event.eventDate instanceof Date ? event.eventDate : new Date(event.eventDate);
+  if (Number.isNaN(eventDate.getTime())) return false;
+
+  return now < eventDate;
+};
+
+/**
+ * @param {{ eventDate?: string|Date }|null|undefined} event
+ * @param {Date} [now]
+ * @returns {boolean}
+ */
+export const isPastEvent = (event, now = new Date()) => !isEventRegistrationOpen(event, now);

--- a/tests/registrationWindow.test.js
+++ b/tests/registrationWindow.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { isEventRegistrationOpen, isPastEvent } from '../src/utils/events/registrationWindow';
+
+describe('registrationWindow', () => {
+  const eventDate = '2026-08-01T18:00:00.000Z';
+  const event = { eventDate };
+
+  test('is open when now is before eventDate', () => {
+    expect(isEventRegistrationOpen(event, new Date('2026-08-01T17:59:59.999Z'))).toBe(true);
+    expect(isPastEvent(event, new Date('2026-08-01T17:59:59.999Z'))).toBe(false);
+  });
+
+  test('is closed when now equals or is after eventDate', () => {
+    expect(isEventRegistrationOpen(event, new Date(eventDate))).toBe(false);
+    expect(isPastEvent(event, new Date('2026-08-01T18:00:00.001Z'))).toBe(true);
+  });
+
+  test('is closed when eventDate is missing or invalid', () => {
+    expect(isEventRegistrationOpen({}, new Date(eventDate))).toBe(false);
+    expect(isEventRegistrationOpen({ eventDate: 'not-a-date' }, new Date(eventDate))).toBe(false);
+    expect(isEventRegistrationOpen(null, new Date(eventDate))).toBe(false);
+  });
+});


### PR DESCRIPTION
Mirror the backend registration window on the client so free RSVP, ticket checkout, and volunteer forms are disabled after `eventDate`. Improve the public events page with Upcoming / Past / All browsing, warmer Misqabbi copy, and a simpler filter bar that drops weak text search in favor of time pills plus a pill-styled Free/Paid dropdown.

**Key changes**
- Add client registration-window helpers (`isEventRegistrationOpen` / `isPastEvent`) with tests
- Disable registration, ticket, and volunteer panels when the event has closed
- Add Upcoming / Past / All filter controls and pass `when` to the events API
- Soften Upcoming / Past / All sublines and empty-state copy in Misqabbi brand voice
- Remove text search from the events page and put time pills + type filter on one toolbar
- Replace the native type `<select>` with a pill-styled `EventTypeFilterDropdown` (wallet icon, custom menu, `cursor-pointer`)