### PR TITLE
Improve product detail UX and hide spots remaining on past events

### DIFF
--- a/src/components/products/GalleryImages.jsx
+++ b/src/components/products/GalleryImages.jsx
@@ -176,7 +176,7 @@ function GalleryImages({
   return (
     <div className="w-full lg:px-0">
       <div
-        className="relative aspect-[2/3] max-h-[calc(100svh-4rem)] min-h-0 w-full overflow-hidden sm:max-h-[calc(100svh-5rem)] lg:max-h-[calc(100vh-6rem)]"
+        className="relative aspect-[2/3] max-h-[calc(100svh-7rem)] min-h-0 w-full overflow-hidden sm:max-h-[calc(100svh-8rem)] lg:max-h-[calc(100vh-6rem)]"
         onMouseEnter={handleGalleryMouseEnter}
         onMouseLeave={handleGalleryMouseLeave}
         onPointerDown={pauseAutoScroll}

--- a/src/components/products/GalleryImages.jsx
+++ b/src/components/products/GalleryImages.jsx
@@ -176,7 +176,7 @@ function GalleryImages({
   return (
     <div className="w-full lg:px-0">
       <div
-        className="relative aspect-[2/3] max-h-[calc(100svh-7rem)] min-h-0 w-full overflow-hidden sm:max-h-[calc(100svh-8rem)] lg:max-h-[calc(100vh-10rem)]"
+        className="relative aspect-[2/3] max-h-[calc(100svh-4rem)] min-h-0 w-full overflow-hidden sm:max-h-[calc(100svh-5rem)] lg:max-h-[calc(100vh-6rem)]"
         onMouseEnter={handleGalleryMouseEnter}
         onMouseLeave={handleGalleryMouseLeave}
         onPointerDown={pauseAutoScroll}

--- a/src/components/products/GalleryImages.jsx
+++ b/src/components/products/GalleryImages.jsx
@@ -176,7 +176,7 @@ function GalleryImages({
   return (
     <div className="w-full lg:px-0">
       <div
-        className="relative aspect-[4/5] max-h-[calc(100svh-7rem)] min-h-0 w-full overflow-hidden sm:max-h-[calc(100svh-8rem)] lg:max-h-[calc(100vh-10rem)]"
+        className="relative aspect-[2/3] max-h-[calc(100svh-7rem)] min-h-0 w-full overflow-hidden sm:max-h-[calc(100svh-8rem)] lg:max-h-[calc(100vh-10rem)]"
         onMouseEnter={handleGalleryMouseEnter}
         onMouseLeave={handleGalleryMouseLeave}
         onPointerDown={pauseAutoScroll}

--- a/src/components/products/ProductDetailsSkeleton.jsx
+++ b/src/components/products/ProductDetailsSkeleton.jsx
@@ -94,7 +94,7 @@ const MobileProductDetailsSkeleton = () => {
     <div className="md:hidden">
       <div className="-mx-3 flex flex-col gap-3">
         <GallerySkeleton
-          imageClassName="h-[min(150vw,calc(100svh-4rem))]"
+          imageClassName="h-[min(150vw,calc(100svh-7rem))]"
           thumbnails={mobileThumbnails}
           thumbnailClassName="flex-[0_0_25%]"
         />
@@ -112,7 +112,7 @@ const TabletProductDetailsSkeleton = () => {
     <div className="hidden md:block lg:hidden">
       <div className="-mx-4 flex flex-col gap-4">
         <GallerySkeleton
-          imageClassName="h-[min(150vw,calc(100svh-5rem))]"
+          imageClassName="h-[min(150vw,calc(100svh-8rem))]"
           thumbnails={tabletThumbnails}
           thumbnailClassName="flex-[0_0_19%]"
         />

--- a/src/components/products/ProductDetailsSkeleton.jsx
+++ b/src/components/products/ProductDetailsSkeleton.jsx
@@ -94,7 +94,7 @@ const MobileProductDetailsSkeleton = () => {
     <div className="md:hidden">
       <div className="-mx-3 flex flex-col gap-3">
         <GallerySkeleton
-          imageClassName="h-[min(125vw,calc(100svh-7rem))]"
+          imageClassName="h-[min(150vw,calc(100svh-4rem))]"
           thumbnails={mobileThumbnails}
           thumbnailClassName="flex-[0_0_25%]"
         />
@@ -112,7 +112,7 @@ const TabletProductDetailsSkeleton = () => {
     <div className="hidden md:block lg:hidden">
       <div className="-mx-4 flex flex-col gap-4">
         <GallerySkeleton
-          imageClassName="h-[min(125vw,calc(100svh-8rem))]"
+          imageClassName="h-[min(150vw,calc(100svh-5rem))]"
           thumbnails={tabletThumbnails}
           thumbnailClassName="flex-[0_0_19%]"
         />
@@ -130,7 +130,7 @@ const DesktopProductDetailsSkeleton = () => {
     <div className="hidden lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start">
       <div className="flex flex-col gap-5">
         <GallerySkeleton
-          imageClassName="h-[min(62.5vw,calc(100vh-10rem))] max-h-[calc(100vh-10rem)]"
+          imageClassName="h-[min(75vw,calc(100vh-6rem))] max-h-[calc(100vh-6rem)]"
           thumbnails={desktopThumbnails}
           thumbnailClassName="flex-[0_0_16.5%]"
         />

--- a/src/components/products/SizeSelect.jsx
+++ b/src/components/products/SizeSelect.jsx
@@ -15,7 +15,7 @@ function SizeSelect({
   onToggleCustomSize,
   supportsCustomSizing = false,
 }) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const [isSizeGuideOpen, setIsSizeGuideOpen] = useState(false);
   const sizes = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
 

--- a/src/components/products/VariantSelector.jsx
+++ b/src/components/products/VariantSelector.jsx
@@ -24,7 +24,7 @@ function VariantSelector({ baseProduct, variants = [], selectedVariant, onSelect
   // Check if base product is selected (selectedVariant is null)
   const isBaseSelected = selectedVariant === null;
   const swatchButtonBaseClasses =
-    'relative w-12 h-12 sm:w-14 sm:h-14 rounded-none overflow-hidden border-2 bg-white transition-all duration-200';
+    'relative w-12 h-12 sm:w-14 sm:h-14 cursor-pointer rounded-none overflow-hidden border-2 bg-white transition-all duration-200';
   const selectedSwatchClasses = 'border-msq-gold-light ring-2 ring-msq-gold-light ring-offset-2';
   const unselectedSwatchClasses =
     'border-gray-300 hover:border-msq-gold-light hover:-translate-y-0.5';

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -10,7 +10,7 @@ import NotFound from '../components/ui/NotFound';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { useEvent } from '../hooks/queries/useEvents';
 import { EVENT_TYPE, EVENT_TYPE_LABELS } from '../constants/events';
-import { formatEventDate, formatEventVenue, getEventTypeColor } from '../utils/events';
+import { formatEventDate, formatEventVenue, getEventTypeColor, isPastEvent } from '../utils/events';
 import scrollToTop from '../utils/scrollToTop';
 
 const getSpotsLabel = spotsRemaining => {
@@ -65,6 +65,7 @@ const EventDetails = () => {
   const venueLabel = formatEventVenue(event.venue);
   const venueLink = event.venue?.url || event.venue?.link;
   const spotsLabel = getSpotsLabel(event.spotsRemaining);
+  const showSpotsRemaining = Boolean(spotsLabel) && !isPastEvent(event);
   const isFree = event.type === EVENT_TYPE.FREE;
   const isPaid = event.type === EVENT_TYPE.PAID;
   const hasVolunteerForm = Boolean(event.volunteerForm);
@@ -114,7 +115,7 @@ const EventDetails = () => {
                   <Calendar className="w-4 h-4 mt-0.5 shrink-0" aria-hidden="true" />
                   <span>{formatEventDate(event.eventDate)}</span>
                 </p>
-                {spotsLabel && (
+                {showSpotsRemaining && (
                   <p className="flex items-center justify-center gap-2 font-medium text-msq-purple-deep sm:justify-start">
                     <Users className="w-4 h-4 shrink-0" aria-hidden="true" />
                     <span>{spotsLabel}</span>


### PR DESCRIPTION
**Description**  
Refines the product detail page so size selection is harder to miss, product imagery shows more of the garment on desktop without breaking the mobile/tablet gallery+thumbnail viewport fit, and variant swatches feel more interactive. Also cleans up event details by hiding remaining spots once an event is past.

**Key changes**
- Open the size selector by default on the product detail page
- Align the main gallery to a `2/3` aspect ratio to better match thumbnails and show more garment length
- Raise the desktop gallery max-height while keeping the tighter mobile/tablet caps so gallery and thumbnails still fit in-viewport
- Sync product detail skeleton heights with the updated gallery proportions
- Hide “spots remaining” on past events in event details